### PR TITLE
Feature/sam+domainport

### DIFF
--- a/cmake/ports/sdl2/CONTROL
+++ b/cmake/ports/sdl2/CONTROL
@@ -1,6 +1,5 @@
 Source: sdl2
 Version: 2.0.10-2
-Homepage: https://github.com/SDL-Mirror/SDL
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
 
 Feature: vulkan

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2107,7 +2107,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         }
         return false;
     });
-    EntityTree::setGetUnscaledDimensionsForEntityIDOperator([this](const QUuid& id) {
+    EntityTree::setGetUnscaledDimensionsForIDOperator([this](const QUuid& id) {
         if (_aboutToQuit) {
             return glm::vec3(1.0f);
         }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2107,6 +2107,23 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         }
         return false;
     });
+    EntityTree::setGetUnscaledDimensionsForEntityIDOperator([this](const QUuid& id) {
+        if (_aboutToQuit) {
+            return glm::vec3(1.0f);
+        }
+
+        auto entity = getEntities()->getEntity(id);
+        if (entity) {
+            return entity->getUnscaledDimensions();
+        }
+
+        auto avatarManager = DependencyManager::get<AvatarManager>();
+        auto avatar = static_pointer_cast<Avatar>(avatarManager->getAvatarBySessionID(id));
+        if (avatar) {
+            return avatar->getSNScale();
+        }
+        return glm::vec3(1.0f);
+    });
     Procedural::opaqueStencil = [](gpu::StatePointer state) { PrepareStencil::testMaskDrawShape(*state); };
     Procedural::transparentStencil = [](gpu::StatePointer state) { PrepareStencil::testMask(*state); };
 

--- a/interface/src/graphics/WorldBox.cpp
+++ b/interface/src/graphics/WorldBox.cpp
@@ -22,7 +22,7 @@ namespace render {
             PerformanceTimer perfTimer("worldBox");
 
             auto& batch = *args->_batch;
-            DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false, true, false, false, true, args->_renderMethod == Args::RenderMethod::FORWARD);
+            DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false, false, false, true, args->_renderMethod == Args::RenderMethod::FORWARD);
             WorldBoxRenderData::renderWorldBox(args, batch);
         }
     }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -791,7 +791,7 @@ void Avatar::render(RenderArgs* renderArgs) {
                 pointerTransform.setTranslation(position);
                 pointerTransform.setRotation(rotation);
                 batch.setModelTransform(pointerTransform);
-                geometryCache->bindSimpleProgram(batch, false, false, true, false, false, true, renderArgs->_renderMethod == render::Args::FORWARD);
+                geometryCache->bindSimpleProgram(batch, false, false, false, false, true, renderArgs->_renderMethod == render::Args::FORWARD);
                 geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, laserLength, 0.0f), laserColor, _leftPointerGeometryID);
             }
         }
@@ -815,7 +815,7 @@ void Avatar::render(RenderArgs* renderArgs) {
                 pointerTransform.setTranslation(position);
                 pointerTransform.setRotation(rotation);
                 batch.setModelTransform(pointerTransform);
-                geometryCache->bindSimpleProgram(batch, false, false, true, false, false, true, renderArgs->_renderMethod == render::Args::FORWARD);
+                geometryCache->bindSimpleProgram(batch, false, false, false, false, true, renderArgs->_renderMethod == render::Args::FORWARD);
                 geometryCache->renderLine(batch, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, laserLength, 0.0f), laserColor, _rightPointerGeometryID);
             }
         }
@@ -1103,7 +1103,7 @@ void Avatar::renderDisplayName(gpu::Batch& batch, const ViewFrustum& view, const
 
         {
             PROFILE_RANGE_BATCH(batch, __FUNCTION__":renderBevelCornersRect");
-            DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false, true, true, true, true, forward);
+            DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false, true, true, true, forward);
             DependencyManager::get<GeometryCache>()->renderBevelCornersRect(batch, left, bottom, width, height,
                 bevelDistance, backgroundColor, _nameRectGeometryID);
         }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -2121,7 +2121,8 @@ void Avatar::updateAttachmentRenderIDs() {
 
 void Avatar::updateDescendantRenderIDs() {
     _subItemLock.withWriteLock([&] {
-        auto oldDescendantRenderIDs = _descendantRenderIDs;
+        auto oldRenderingDescendantEntityIDs = _renderingDescendantEntityIDs;
+        _renderingDescendantEntityIDs.clear();
         _descendantRenderIDs.clear();
         auto entityTreeRenderer = DependencyManager::get<EntityTreeRenderer>();
         EntityTreePointer entityTree = entityTreeRenderer ? entityTreeRenderer->getTree() : nullptr;
@@ -2131,34 +2132,30 @@ void Avatar::updateDescendantRenderIDs() {
                     if (object && object->getNestableType() == NestableType::Entity) {
                         EntityItemPointer entity = std::static_pointer_cast<EntityItem>(object);
                         if (entity->isVisible()) {
-                            auto renderer = entityTreeRenderer->renderableForEntityId(object->getID());
+                            auto id = object->getID();
+                            _renderingDescendantEntityIDs.insert(id);
+                            oldRenderingDescendantEntityIDs.erase(id);
+                            entity->setCullWithParent(true);
+
+                            auto renderer = entityTreeRenderer->renderableForEntityId(id);
                             if (renderer) {
                                 render::ItemIDs renderableSubItems;
                                 uint32_t numRenderableSubItems = renderer->metaFetchMetaSubItems(renderableSubItems);
                                 if (numRenderableSubItems > 0) {
-                                    for (auto& renderID : renderableSubItems) {
-                                        _descendantRenderIDs.insert(renderID);
-                                        oldDescendantRenderIDs.erase(renderID);
-                                    }
+                                    _descendantRenderIDs.insert(_descendantRenderIDs.end(), renderableSubItems.begin(), renderableSubItems.end());
                                 }
                             }
                         }
                     }
                 });
-            });
 
-            render::Transaction transaction;
-            for (auto& oldDescendantRenderID : oldDescendantRenderIDs) {
-                transaction.updateItem<render::PayloadProxyInterface>(oldDescendantRenderID, [](render::PayloadProxyInterface& self) {
-                    self.setOverrideSubMetaCulled(false);
-                });
-            }
-            for (auto& descendantRenderIDs : _descendantRenderIDs) {
-                transaction.updateItem<render::PayloadProxyInterface>(descendantRenderIDs, [](render::PayloadProxyInterface& self) {
-                    self.setOverrideSubMetaCulled(true);
-                });
-            }
-            AbstractViewStateInterface::instance()->getMain3DScene()->enqueueTransaction(transaction);
+                for (auto& oldRenderingDescendantEntityID : oldRenderingDescendantEntityIDs) {
+                    auto entity = entityTree->findEntityByEntityItemID(oldRenderingDescendantEntityID);
+                    if (entity) {
+                        entity->setCullWithParent(false);
+                    }
+                }
+            });
         }
     });
 }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -2121,6 +2121,7 @@ void Avatar::updateAttachmentRenderIDs() {
 
 void Avatar::updateDescendantRenderIDs() {
     _subItemLock.withWriteLock([&] {
+        auto oldDescendantRenderIDs = _descendantRenderIDs;
         _descendantRenderIDs.clear();
         auto entityTreeRenderer = DependencyManager::get<EntityTreeRenderer>();
         EntityTreePointer entityTree = entityTreeRenderer ? entityTreeRenderer->getTree() : nullptr;
@@ -2135,13 +2136,29 @@ void Avatar::updateDescendantRenderIDs() {
                                 render::ItemIDs renderableSubItems;
                                 uint32_t numRenderableSubItems = renderer->metaFetchMetaSubItems(renderableSubItems);
                                 if (numRenderableSubItems > 0) {
-                                    _descendantRenderIDs.insert(_descendantRenderIDs.end(), renderableSubItems.begin(), renderableSubItems.end());
+                                    for (auto& renderID : renderableSubItems) {
+                                        _descendantRenderIDs.insert(renderID);
+                                        oldDescendantRenderIDs.erase(renderID);
+                                    }
                                 }
                             }
                         }
                     }
                 });
             });
+
+            render::Transaction transaction;
+            for (auto& oldDescendantRenderID : oldDescendantRenderIDs) {
+                transaction.updateItem<render::PayloadProxyInterface>(oldDescendantRenderID, [](render::PayloadProxyInterface& self) {
+                    self.setOverrideSubMetaCulled(false);
+                });
+            }
+            for (auto& descendantRenderIDs : _descendantRenderIDs) {
+                transaction.updateItem<render::PayloadProxyInterface>(descendantRenderIDs, [](render::PayloadProxyInterface& self) {
+                    self.setOverrideSubMetaCulled(true);
+                });
+            }
+            AbstractViewStateInterface::instance()->getMain3DScene()->enqueueTransaction(transaction);
         }
     });
 }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -781,7 +781,7 @@ protected:
     void updateAttachmentRenderIDs();
     render::ItemIDs _attachmentRenderIDs;
     void updateDescendantRenderIDs();
-    render::ItemIDs _descendantRenderIDs;
+    render::ItemIDSet _descendantRenderIDs;
     uint32_t _lastAncestorChainRenderableVersion { 0 };
 };
 

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -781,7 +781,8 @@ protected:
     void updateAttachmentRenderIDs();
     render::ItemIDs _attachmentRenderIDs;
     void updateDescendantRenderIDs();
-    render::ItemIDSet _descendantRenderIDs;
+    render::ItemIDs _descendantRenderIDs;
+    std::unordered_set<EntityItemID> _renderingDescendantEntityIDs;
     uint32_t _lastAncestorChainRenderableVersion { 0 };
 };
 

--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -168,19 +168,20 @@ render::hifi::Layer EntityRenderer::getHifiRenderLayer() const {
 }
 
 ItemKey EntityRenderer::getKey() {
-    ItemKey::Builder builder = ItemKey::Builder().withTypeShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
-
+    auto builder = ItemKey::Builder().withTypeShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
     if (isTransparent()) {
         builder.withTransparent();
-    } else if (_canCastShadow) {
+    }
+
+    if (_canCastShadow) {
         builder.withShadowCaster();
     }
 
-    if (!_visible) {
-        builder.withInvisible();
+    if (_cullWithParent) {
+        builder.withSubMetaCulled();
     }
 
-    return builder;
+    return builder.build();
 }
 
 uint32_t EntityRenderer::metaFetchMetaSubItems(ItemIDs& subItems) const {
@@ -419,6 +420,7 @@ void EntityRenderer::doRenderUpdateSynchronous(const ScenePointer& scene, Transa
         setRenderLayer(entity->getRenderLayer());
         setPrimitiveMode(entity->getPrimitiveMode());
         _canCastShadow = entity->getCanCastShadow();
+        setCullWithParent(entity->getCullWithParent());
         _cauterized = entity->getCauterized();
         entity->setNeedsRenderUpdate(false);
     });

--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -168,12 +168,12 @@ render::hifi::Layer EntityRenderer::getHifiRenderLayer() const {
 }
 
 ItemKey EntityRenderer::getKey() {
-    auto builder = ItemKey::Builder().withTypeShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+    ItemKey::Builder builder =
+        ItemKey::Builder().withTypeShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+
     if (isTransparent()) {
         builder.withTransparent();
-    }
-
-    if (_canCastShadow) {
+    } else if (_canCastShadow) {
         builder.withShadowCaster();
     }
 
@@ -181,7 +181,11 @@ ItemKey EntityRenderer::getKey() {
         builder.withSubMetaCulled();
     }
 
-    return builder.build();
+    if (!_visible) {
+        builder.withInvisible();
+    }
+
+    return builder;
 }
 
 uint32_t EntityRenderer::metaFetchMetaSubItems(ItemIDs& subItems) const {

--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -108,6 +108,16 @@ protected:
     virtual void setIsVisibleInSecondaryCamera(bool value) { _isVisibleInSecondaryCamera = value; }
     virtual void setRenderLayer(RenderLayer value) { _renderLayer = value; }
     virtual void setPrimitiveMode(PrimitiveMode value) { _primitiveMode = value; }
+    virtual void setCullWithParent(bool value) { _cullWithParent = value; }
+
+    template <typename F, typename T>
+    T withReadLockResult(const std::function<T()>& f) {
+        T result;
+        withReadLock([&] {
+            result = f();
+        });
+        return result;
+    }
 
 signals:
     void requestRenderUpdate();
@@ -130,6 +140,7 @@ protected:
     bool _visible { false };
     bool _isVisibleInSecondaryCamera { false };
     bool _canCastShadow { false };
+    bool _cullWithParent { false };
     RenderLayer _renderLayer { RenderLayer::WORLD };
     PrimitiveMode _primitiveMode { PrimitiveMode::SOLID };
     bool _cauterized { false };

--- a/libraries/entities-renderer/src/RenderableGizmoEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableGizmoEntityItem.cpp
@@ -253,7 +253,7 @@ void GizmoEntityRenderer::doRender(RenderArgs* args) {
         });
 
         bool wireframe = render::ShapeKey(args->_globalShapeKey).isWireframe() || _primitiveMode == PrimitiveMode::LINES;
-        geometryCache->bindSimpleProgram(batch, false, isTransparent(), false, wireframe, true, true, forward);
+        geometryCache->bindSimpleProgram(batch, false, isTransparent(), wireframe, true, true, forward, graphics::MaterialKey::CULL_NONE);
 
         batch.setModelTransform(transform);
 

--- a/libraries/entities-renderer/src/RenderableLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableLineEntityItem.cpp
@@ -50,7 +50,7 @@ void LineEntityRenderer::doRender(RenderArgs* args) {
     transform.setRotation(modelTransform.getRotation());
     batch.setModelTransform(transform);
     if (_linePoints.size() > 1) {
-        DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false, true, false, false, true,
+        DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false, false, false, true,
             _renderLayer != RenderLayer::WORLD || args->_renderMethod == Args::RenderMethod::FORWARD);
         DependencyManager::get<GeometryCache>()->renderVertices(batch, gpu::LINE_STRIP, _lineVerticesID);
     }

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
@@ -153,13 +153,13 @@ void MaterialEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPo
 
         if (urlChanged && !usingMaterialData) {
             _networkMaterial = DependencyManager::get<MaterialCache>()->getMaterial(_materialURL);
-            auto onMaterialRequestFinished = [this, oldParentID, oldParentMaterialName, newCurrentMaterialName](bool success) {
+            auto onMaterialRequestFinished = [this, entity, oldParentID, oldParentMaterialName, newCurrentMaterialName](bool success) {
                 if (success) {
                     deleteMaterial(oldParentID, oldParentMaterialName);
                     _texturesLoaded = false;
                     _parsedMaterials = _networkMaterial->parsedMaterials;
                     setCurrentMaterialName(newCurrentMaterialName);
-                    applyMaterial();
+                    applyMaterial(entity);
                 } else {
                     deleteMaterial(oldParentID, oldParentMaterialName);
                     _retryApply = false;
@@ -183,13 +183,13 @@ void MaterialEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPo
             _parsedMaterials = NetworkMaterialResource::parseJSONMaterials(QJsonDocument::fromJson(_materialData.toUtf8()), _materialURL);
             // Since our material changed, the current name might not be valid anymore, so we need to update
             setCurrentMaterialName(newCurrentMaterialName);
-            applyMaterial();
+            applyMaterial(entity);
         } else {
             if (deleteNeeded) {
                 deleteMaterial(oldParentID, oldParentMaterialName);
             }
             if (addNeeded) {
-                applyMaterial();
+                applyMaterial(entity);
             }
         }
 
@@ -382,7 +382,7 @@ void MaterialEntityRenderer::applyTextureTransform(std::shared_ptr<NetworkMateri
     material->setTextureTransforms(textureTransform, _materialMappingMode, _materialRepeat);
 }
 
-void MaterialEntityRenderer::applyMaterial() {
+void MaterialEntityRenderer::applyMaterial(const TypedEntityPointer& entity) {
     _retryApply = false;
 
     std::shared_ptr<NetworkMaterial> material = getMaterial();
@@ -395,6 +395,11 @@ void MaterialEntityRenderer::applyMaterial() {
     applyTextureTransform(material);
 
     graphics::MaterialLayer materialLayer = graphics::MaterialLayer(material, _priority);
+
+    if (auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(material)) {
+        procedural->setBoundOperator([this] { return getBound(); });
+        entity->setHasVertexShader(procedural->hasVertexShader());
+    }
 
     // Our parent could be an entity or an avatar
     std::string parentMaterialName = _parentMaterialName.toStdString();

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
@@ -210,8 +210,7 @@ void MaterialEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPo
 }
 
 ItemKey MaterialEntityRenderer::getKey() {
-    ItemKey::Builder builder;
-    builder.withTypeShape().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+    auto builder = ItemKey::Builder().withTypeShape().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
 
     if (!_visible) {
         builder.withInvisible();

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
@@ -395,7 +395,8 @@ void MaterialEntityRenderer::applyMaterial(const TypedEntityPointer& entity) {
 
     graphics::MaterialLayer materialLayer = graphics::MaterialLayer(material, _priority);
 
-    if (auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(material)) {
+    if (material->isProcedural()) {
+        auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(material);
         procedural->setBoundOperator([this] { return getBound(); });
         entity->setHasVertexShader(procedural->hasVertexShader());
     }

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.h
@@ -56,7 +56,7 @@ private:
     void setCurrentMaterialName(const std::string& currentMaterialName);
 
     void applyTextureTransform(std::shared_ptr<NetworkMaterial>& material);
-    void applyMaterial();
+    void applyMaterial(const TypedEntityPointer& entity);
     void deleteMaterial(const QUuid& oldParentID, const QString& oldParentMaterialName);
 
     NetworkMaterialResourcePointer _networkMaterial;

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1060,7 +1060,7 @@ void ModelEntityRenderer::setKey(bool didVisualGeometryRequestSucceed) {
     if (!_cullWithParent && _model && _model->isGroupCulled()) {
         builder.withMetaCullGroup();
     } else if (_cullWithParent) {
-        builder.withoutSubMetaCulled();
+        builder.withSubMetaCulled();
     }
 
     if (didVisualGeometryRequestSucceed) {

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1057,8 +1057,10 @@ ModelEntityRenderer::ModelEntityRenderer(const EntityItemPointer& entity) : Pare
 void ModelEntityRenderer::setKey(bool didVisualGeometryRequestSucceed) {
     auto builder = ItemKey::Builder().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
 
-    if (_model && _model->isGroupCulled()) {
+    if (!_cullWithParent && _model && _model->isGroupCulled()) {
         builder.withMetaCullGroup();
+    } else if (_cullWithParent) {
+        builder.withoutSubMetaCulled();
     }
 
     if (didVisualGeometryRequestSucceed) {
@@ -1494,6 +1496,14 @@ void ModelEntityRenderer::setPrimitiveMode(PrimitiveMode value) {
     Parent::setPrimitiveMode(value);
     if (_model) {
         _model->setPrimitiveMode(_primitiveMode);
+    }
+}
+
+void ModelEntityRenderer::setCullWithParent(bool value) {
+    Parent::setCullWithParent(value);
+    setKey(_didLastVisualGeometryRequestSucceed);
+    if (_model) {
+        _model->setCullWithParent(_cullWithParent);
     }
 }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -164,6 +164,7 @@ protected:
     void setIsVisibleInSecondaryCamera(bool value) override;
     void setRenderLayer(RenderLayer value) override;
     void setPrimitiveMode(PrimitiveMode value) override;
+    void setCullWithParent(bool value) override;
 
 private:
     void animate(const TypedEntityPointer& entity);

--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
@@ -151,11 +151,17 @@ void ParticleEffectEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEn
 
 ItemKey ParticleEffectEntityRenderer::getKey() {
     // FIXME: implement isTransparent() for particles and an opaque pipeline
-    if (_visible) {
-        return ItemKey::Builder::transparentShape().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
-    } else {
-        return ItemKey::Builder().withInvisible().withTagBits(getTagMask()).withLayer(getHifiRenderLayer()).build();
+    auto builder = ItemKey::Builder::transparentShape().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+
+    if (!_visible) {
+        builder.withInvisible();
     }
+
+    if (_cullWithParent) {
+        builder.withSubMetaCulled();
+    }
+
+    return builder.build();
 }
 
 ShapeKey ParticleEffectEntityRenderer::getShapeKey() {

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -97,9 +97,14 @@ void PolyLineEntityRenderer::buildPipelines() {
 }
 
 ItemKey PolyLineEntityRenderer::getKey() {
-    return isTransparent() ?
-        ItemKey::Builder::transparentShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer()) :
-        ItemKey::Builder::opaqueShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+    // FIXME: implement isTransparent() for polylines and an opaque pipeline
+    auto builder = ItemKey::Builder::transparentShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+
+    if (_cullWithParent) {
+        builder.withSubMetaCulled();
+    }
+
+    return builder.build();
 }
 
 ShapeKey PolyLineEntityRenderer::getShapeKey() {

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -97,8 +97,11 @@ void PolyLineEntityRenderer::buildPipelines() {
 }
 
 ItemKey PolyLineEntityRenderer::getKey() {
-    // FIXME: implement isTransparent() for polylines and an opaque pipeline
-    auto builder = ItemKey::Builder::transparentShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+    auto builder = ItemKey::Builder::opaqueShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+
+    if (isTransparent()) {
+        builder.withTransparent();
+    }
 
     if (_cullWithParent) {
         builder.withSubMetaCulled();

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -1783,6 +1783,16 @@ PolyVoxEntityRenderer::PolyVoxEntityRenderer(const EntityItemPointer& entity) : 
     _params = std::make_shared<gpu::Buffer>(sizeof(glm::vec4), nullptr);
 }
 
+ItemKey PolyVoxEntityRenderer::getKey() {
+    auto builder = ItemKey::Builder::opaqueShape().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+
+    if (_cullWithParent) {
+        builder.withSubMetaCulled();
+    }
+
+    return builder.build();
+}
+
 ShapeKey PolyVoxEntityRenderer::getShapeKey() {
     auto builder = ShapeKey::Builder().withCustom(CUSTOM_PIPELINE_NUMBER);
     if (_primitiveMode == PrimitiveMode::LINES) {

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
@@ -209,7 +209,7 @@ public:
     }
 
 protected:
-    virtual ItemKey getKey() override { return ItemKey::Builder::opaqueShape().withTagBits(getTagMask()).withLayer(getHifiRenderLayer()); }
+    virtual ItemKey getKey() override;
     virtual ShapeKey getShapeKey() override;
     virtual bool needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const override;
     virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -200,6 +200,7 @@ ShapeKey ShapeEntityRenderer::getShapeKey() {
         if (drawMaterialKey.isUnlit()) {
             builder.withUnlit();
         }
+        builder.withCullFaceMode(mat->second.getCullFaceMode());
     } else if (pipelineType == Pipeline::PROCEDURAL) {
         builder.withOwnPipeline();
     }
@@ -263,7 +264,7 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
         // FIXME, support instanced multi-shape rendering using multidraw indirect
         outColor.a *= _isFading ? Interpolate::calculateFadeRatio(_fadeStartTime) : 1.0f;
         render::ShapePipelinePointer pipeline = geometryCache->getShapePipelinePointer(outColor.a < 1.0f, false,
-            renderLayer != RenderLayer::WORLD || args->_renderMethod == Args::RenderMethod::FORWARD);
+            renderLayer != RenderLayer::WORLD || args->_renderMethod == Args::RenderMethod::FORWARD, materials.top().material->getCullFaceMode());
         if (render::ShapeKey(args->_globalShapeKey).isWireframe() || primitiveMode == PrimitiveMode::LINES) {
             geometryCache->renderWireShapeInstance(args, batch, geometryShape, outColor, pipeline);
         } else {

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -207,6 +207,18 @@ ShapeKey ShapeEntityRenderer::getShapeKey() {
     return builder.build();
 }
 
+Item::Bound ShapeEntityRenderer::getBound() {
+    auto mat = _materials.find("0");
+    if (mat != _materials.end() && mat->second.top().material && mat->second.top().material->isProcedural() &&
+        mat->second.top().material->isReady()) {
+        auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(mat->second.top().material);
+        if (procedural->hasVertexShader() && procedural->hasBoundOperator()) {
+           return procedural->getBound();
+        }
+    }
+    return Parent::getBound();
+}
+
 void ShapeEntityRenderer::doRender(RenderArgs* args) {
     PerformanceTimer perfTimer("RenderableShapeEntityItem::render");
     Q_ASSERT(args->_batch);

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.h
@@ -26,6 +26,7 @@ public:
 
 protected:
     ShapeKey getShapeKey() override;
+    Item::Bound getBound() override;
 
 private:
     virtual bool needsRenderUpdate() const override;

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -3030,10 +3030,10 @@ bool EntityItem::getCullWithParent() const {
 }
 
 void EntityItem::setCullWithParent(bool value) {
-    if (_cullWithParent != value) {
+    withWriteLock([&] {
+        _needsRenderUpdate |= _cullWithParent != value;
         _cullWithParent = value;
-        emit requestRenderUpdate();
-    }
+    });
 }
 
 bool EntityItem::isChildOfMyAvatar() const {

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -3025,6 +3025,17 @@ void EntityItem::setCanCastShadow(bool value) {
     });
 }
 
+bool EntityItem::getCullWithParent() const {
+    return _cullWithParent;
+}
+
+void EntityItem::setCullWithParent(bool value) {
+    if (_cullWithParent != value) {
+        _cullWithParent = value;
+        emit requestRenderUpdate();
+    }
+}
+
 bool EntityItem::isChildOfMyAvatar() const {
     QUuid ancestorID = findAncestorOfType(NestableType::Avatar);
     return !ancestorID.isNull() && (ancestorID == Physics::getSessionUUID() || ancestorID == AVATAR_SELF_ID);

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -305,6 +305,9 @@ public:
     bool getCanCastShadow() const;
     void setCanCastShadow(bool value);
 
+    bool getCullWithParent() const;
+    void setCullWithParent(bool value);
+
     void setCauterized(bool value);
     bool getCauterized() const;
 
@@ -762,7 +765,7 @@ protected:
 
     QHash<QUuid, EntityDynamicPointer> _grabActions;
 
-    mutable bool _needsRenderUpdate { false };
+    bool _cullWithParent { false };
 
 private:
     static std::function<glm::quat(const glm::vec3&, const glm::quat&, BillboardMode, const glm::vec3&)> _getBillboardRotationOperator;

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -579,6 +579,7 @@ public:
 
 signals:
     void spaceUpdate(std::pair<int32_t, glm::vec4> data);
+    void requestRenderUpdate();
 
 protected:
     QHash<ChangeHandlerId, ChangeHandlerCallback> _changeHandlers;
@@ -766,6 +767,8 @@ protected:
     QHash<QUuid, EntityDynamicPointer> _grabActions;
 
     bool _cullWithParent { false };
+    
+    mutable bool _needsRenderUpdate { false };
 
 private:
     static std::function<glm::quat(const glm::vec3&, const glm::quat&, BillboardMode, const glm::vec3&)> _getBillboardRotationOperator;

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -579,7 +579,6 @@ public:
 
 signals:
     void spaceUpdate(std::pair<int32_t, glm::vec4> data);
-    void requestRenderUpdate();
 
 protected:
     QHash<ChangeHandlerId, ChangeHandlerCallback> _changeHandlers;

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -3113,7 +3113,7 @@ std::function<QObject*(const QUuid&)> EntityTree::_getEntityObjectOperator = nul
 std::function<QSizeF(const QUuid&, const QString&)> EntityTree::_textSizeOperator = nullptr;
 std::function<bool()> EntityTree::_areEntityClicksCapturedOperator = nullptr;
 std::function<void(const QUuid&, const QVariant&)> EntityTree::_emitScriptEventOperator = nullptr;
-std::function<glm::vec3(const QUuid&)> EntityTree::_getUnscaledDimensionsForEntityIDOperator = nullptr;
+std::function<glm::vec3(const QUuid&)> EntityTree::_getUnscaledDimensionsForIDOperator = nullptr;
 
 QObject* EntityTree::getEntityObject(const QUuid& id) {
     if (_getEntityObjectOperator) {
@@ -3142,9 +3142,9 @@ void EntityTree::emitScriptEvent(const QUuid& id, const QVariant& message) {
     }
 }
 
-glm::vec3 EntityTree::getUnscaledDimensionsForEntityID(const QUuid& id) {
-    if (_getUnscaledDimensionsForEntityIDOperator) {
-        return _getUnscaledDimensionsForEntityIDOperator(id);
+glm::vec3 EntityTree::getUnscaledDimensionsForID(const QUuid& id) {
+    if (_getUnscaledDimensionsForIDOperator) {
+        return _getUnscaledDimensionsForIDOperator(id);
     }
     return glm::vec3(1.0f);
 }

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -3113,6 +3113,7 @@ std::function<QObject*(const QUuid&)> EntityTree::_getEntityObjectOperator = nul
 std::function<QSizeF(const QUuid&, const QString&)> EntityTree::_textSizeOperator = nullptr;
 std::function<bool()> EntityTree::_areEntityClicksCapturedOperator = nullptr;
 std::function<void(const QUuid&, const QVariant&)> EntityTree::_emitScriptEventOperator = nullptr;
+std::function<glm::vec3(const QUuid&)> EntityTree::_getUnscaledDimensionsForEntityIDOperator = nullptr;
 
 QObject* EntityTree::getEntityObject(const QUuid& id) {
     if (_getEntityObjectOperator) {
@@ -3139,6 +3140,13 @@ void EntityTree::emitScriptEvent(const QUuid& id, const QVariant& message) {
     if (_emitScriptEventOperator) {
         _emitScriptEventOperator(id, message);
     }
+}
+
+glm::vec3 EntityTree::getUnscaledDimensionsForEntityID(const QUuid& id) {
+    if (_getUnscaledDimensionsForEntityIDOperator) {
+        return _getUnscaledDimensionsForEntityIDOperator(id);
+    }
+    return glm::vec3(1.0f);
 }
 
 void EntityTree::updateEntityQueryAACubeWorker(SpatiallyNestablePointer object, EntityEditPacketSender* packetSender,

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -271,8 +271,8 @@ public:
     static void setEmitScriptEventOperator(std::function<void(const QUuid&, const QVariant&)> emitScriptEventOperator) { _emitScriptEventOperator = emitScriptEventOperator; }
     static void emitScriptEvent(const QUuid& id, const QVariant& message);
 
-    static void setGetUnscaledDimensionsForEntityIDOperator(std::function<glm::vec3(const QUuid&)> getUnscaledDimensionsForEntityIDOperator) { _getUnscaledDimensionsForEntityIDOperator = getUnscaledDimensionsForEntityIDOperator; }
-    static glm::vec3 getUnscaledDimensionsForEntityID(const QUuid& id);
+    static void setGetUnscaledDimensionsForIDOperator(std::function<glm::vec3(const QUuid&)> getUnscaledDimensionsForIDOperator) { _getUnscaledDimensionsForIDOperator = getUnscaledDimensionsForIDOperator; }
+    static glm::vec3 getUnscaledDimensionsForID(const QUuid& id);
 
     std::map<QString, QString> getNamedPaths() const { return _namedPaths; }
 
@@ -389,7 +389,7 @@ private:
     static std::function<QSizeF(const QUuid&, const QString&)> _textSizeOperator;
     static std::function<bool()> _areEntityClicksCapturedOperator;
     static std::function<void(const QUuid&, const QVariant&)> _emitScriptEventOperator;
-    static std::function<glm::vec3(const QUuid&)> _getUnscaledDimensionsForEntityIDOperator;
+    static std::function<glm::vec3(const QUuid&)> _getUnscaledDimensionsForIDOperator;
 
     std::vector<int32_t> _staleProxies;
 

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -271,6 +271,9 @@ public:
     static void setEmitScriptEventOperator(std::function<void(const QUuid&, const QVariant&)> emitScriptEventOperator) { _emitScriptEventOperator = emitScriptEventOperator; }
     static void emitScriptEvent(const QUuid& id, const QVariant& message);
 
+    static void setGetUnscaledDimensionsForEntityIDOperator(std::function<glm::vec3(const QUuid&)> getUnscaledDimensionsForEntityIDOperator) { _getUnscaledDimensionsForEntityIDOperator = getUnscaledDimensionsForEntityIDOperator; }
+    static glm::vec3 getUnscaledDimensionsForEntityID(const QUuid& id);
+
     std::map<QString, QString> getNamedPaths() const { return _namedPaths; }
 
     void updateEntityQueryAACube(SpatiallyNestablePointer object, EntityEditPacketSender* packetSender,
@@ -386,6 +389,7 @@ private:
     static std::function<QSizeF(const QUuid&, const QString&)> _textSizeOperator;
     static std::function<bool()> _areEntityClicksCapturedOperator;
     static std::function<void(const QUuid&, const QVariant&)> _emitScriptEventOperator;
+    static std::function<glm::vec3(const QUuid&)> _getUnscaledDimensionsForEntityIDOperator;
 
     std::vector<int32_t> _staleProxies;
 

--- a/libraries/entities/src/MaterialEntityItem.cpp
+++ b/libraries/entities/src/MaterialEntityItem.cpp
@@ -293,7 +293,7 @@ void MaterialEntityItem::setHasVertexShader(bool hasVertexShader) {
     if (hasVertexShader && !prevHasVertexShader) {
         setLocalPosition(glm::vec3(0.0f));
         setLocalOrientation(glm::quat());
-        setUnscaledDimensions(EntityTree::getUnscaledDimensionsForEntityID(getParentID()));
+        setUnscaledDimensions(EntityTree::getUnscaledDimensionsForID(getParentID()));
     } else if (!hasVertexShader && prevHasVertexShader) {
         setUnscaledDimensions(_desiredDimensions);
     }

--- a/libraries/entities/src/MaterialEntityItem.cpp
+++ b/libraries/entities/src/MaterialEntityItem.cpp
@@ -139,10 +139,10 @@ void MaterialEntityItem::debugDump() const {
 
 void MaterialEntityItem::setUnscaledDimensions(const glm::vec3& value) {
     _desiredDimensions = value;
-    if (_materialMappingMode == MaterialMappingMode::UV) {
-        EntityItem::setUnscaledDimensions(ENTITY_ITEM_DEFAULT_DIMENSIONS);
-    } else if (_materialMappingMode == MaterialMappingMode::PROJECTED) {
+    if (_hasVertexShader || _materialMappingMode == MaterialMappingMode::PROJECTED) {
         EntityItem::setUnscaledDimensions(value);
+    } else if (_materialMappingMode == MaterialMappingMode::UV) {
+        EntityItem::setUnscaledDimensions(ENTITY_ITEM_DEFAULT_DIMENSIONS);
     }
 }
 
@@ -264,6 +264,13 @@ void MaterialEntityItem::setMaterialRepeat(bool value) {
     });
 }
 
+void MaterialEntityItem::setParentID(const QUuid& parentID) {
+    if (parentID != getParentID()) {
+        EntityItem::setParentID(parentID);
+        _hasVertexShader = false;
+    }
+}
+
 AACube MaterialEntityItem::calculateInitialQueryAACube(bool& success) {
     AACube aaCube = EntityItem::calculateInitialQueryAACube(success);
     // A Material entity's queryAACube contains its parent's queryAACube
@@ -277,4 +284,17 @@ AACube MaterialEntityItem::calculateInitialQueryAACube(bool& success) {
         }
     }
     return aaCube;
+}
+
+void MaterialEntityItem::setHasVertexShader(bool hasVertexShader) {
+    bool prevHasVertexShader = _hasVertexShader;
+    _hasVertexShader = hasVertexShader;
+
+    if (hasVertexShader && !prevHasVertexShader) {
+        setLocalPosition(glm::vec3(0.0f));
+        setLocalOrientation(glm::quat());
+        setUnscaledDimensions(EntityTree::getUnscaledDimensionsForEntityID(getParentID()));
+    } else if (!hasVertexShader && prevHasVertexShader) {
+        setUnscaledDimensions(_desiredDimensions);
+    }
 }

--- a/libraries/entities/src/MaterialEntityItem.h
+++ b/libraries/entities/src/MaterialEntityItem.h
@@ -64,6 +64,8 @@ public:
     QString getParentMaterialName() const;
     void setParentMaterialName(const QString& parentMaterialName);
 
+    void setParentID(const QUuid& parentID) override;
+
     glm::vec2 getMaterialMappingPos() const;
     void setMaterialMappingPos(const glm::vec2& materialMappingPos);
     glm::vec2 getMaterialMappingScale() const;
@@ -72,6 +74,8 @@ public:
     void setMaterialMappingRot(float materialMappingRot);
 
     AACube calculateInitialQueryAACube(bool& success) override;
+
+    void setHasVertexShader(bool hasVertexShader);
 
 private:
     // URL for this material.  Currently, only JSON format is supported.  Set to "materialData" to use the material data to live edit a material.
@@ -107,6 +111,8 @@ private:
     // How much to rotate this material within its parent's UV-space (degrees)
     float _materialMappingRot { 0 };
     QString _materialData;
+
+    bool _hasVertexShader { false };
 
 };
 

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -1774,6 +1774,10 @@ void GLTFSerializer::setHFMMaterial(HFMMaterial& hfmMat, const GLTFMaterial& mat
         hfmMat._material->setOpacityCutoff(material.alphaCutoff);
     }
 
+    if (material.defined["doubleSided"] && material.doubleSided) {
+        hfmMat._material->setCullFaceMode(graphics::MaterialKey::CullFaceMode::CULL_NONE);
+    }
+
     if (material.defined["emissiveFactor"] && material.emissiveFactor.size() == 3) {
         glm::vec3 emissive = glm::vec3(material.emissiveFactor[0], material.emissiveFactor[1], material.emissiveFactor[2]);
         hfmMat._material->setEmissive(emissive);

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -225,18 +225,17 @@ int GLTFSerializer::getAccessorType(const QString& type)
     return GLTFAccessorType::SCALAR;
 }
 
-int GLTFSerializer::getMaterialAlphaMode(const QString& type)
-{
+graphics::MaterialKey::OpacityMapMode GLTFSerializer::getMaterialAlphaMode(const QString& type) {
     if (type == "OPAQUE") {
-        return GLTFMaterialAlphaMode::OPAQUE;
+        return graphics::MaterialKey::OPACITY_MAP_OPAQUE;
     }
     if (type == "MASK") {
-        return GLTFMaterialAlphaMode::MASK;
+        return graphics::MaterialKey::OPACITY_MAP_MASK;
     }
     if (type == "BLEND") {
-        return GLTFMaterialAlphaMode::BLEND;
+        return graphics::MaterialKey::OPACITY_MAP_BLEND;
     }
-    return GLTFMaterialAlphaMode::OPAQUE;
+    return graphics::MaterialKey::OPACITY_MAP_BLEND;
 }
 
 int GLTFSerializer::getCameraType(const QString& type)
@@ -484,9 +483,9 @@ bool GLTFSerializer::addMaterial(const QJsonObject& object) {
     getIndexFromObject(object, "normalTexture", material.normalTexture, material.defined);
     getIndexFromObject(object, "occlusionTexture", material.occlusionTexture, material.defined);
     getBoolVal(object, "doubleSided", material.doubleSided, material.defined);
-    QString alphamode;
-    if (getStringVal(object, "alphaMode", alphamode, material.defined)) {
-        material.alphaMode = getMaterialAlphaMode(alphamode);
+    QString alphaMode;
+    if (getStringVal(object, "alphaMode", alphaMode, material.defined)) {
+        material.alphaMode = getMaterialAlphaMode(alphaMode);
     }
     getDoubleVal(object, "alphaCutoff", material.alphaCutoff, material.defined);
     QJsonObject jsMetallicRoughness;
@@ -1764,62 +1763,68 @@ HFMTexture GLTFSerializer::getHFMTexture(const GLTFTexture& texture) {
     return fbxtex;
 }
 
-void GLTFSerializer::setHFMMaterial(HFMMaterial& fbxmat, const GLTFMaterial& material) {
+void GLTFSerializer::setHFMMaterial(HFMMaterial& hfmMat, const GLTFMaterial& material) {
+    if (material.defined["alphaMode"]) {
+        hfmMat._material->setOpacityMapMode(material.alphaMode);
+    } else {
+        hfmMat._material->setOpacityMapMode(graphics::MaterialKey::OPACITY_MAP_OPAQUE); // GLTF defaults to opaque
+    }
 
+    if (material.defined["alphaCutoff"]) {
+        hfmMat._material->setOpacityCutoff(material.alphaCutoff);
+    }
 
     if (material.defined["emissiveFactor"] && material.emissiveFactor.size() == 3) {
-        glm::vec3 emissive = glm::vec3(material.emissiveFactor[0], 
-                                       material.emissiveFactor[1], 
-                                       material.emissiveFactor[2]);
-        fbxmat._material->setEmissive(emissive);
+        glm::vec3 emissive = glm::vec3(material.emissiveFactor[0], material.emissiveFactor[1], material.emissiveFactor[2]);
+        hfmMat._material->setEmissive(emissive);
     }
 
     if (material.defined["emissiveTexture"]) {
-        fbxmat.emissiveTexture = getHFMTexture(_file.textures[material.emissiveTexture]);
-        fbxmat.useEmissiveMap = true;
+        hfmMat.emissiveTexture = getHFMTexture(_file.textures[material.emissiveTexture]);
+        hfmMat.useEmissiveMap = true;
     }
     
     if (material.defined["normalTexture"]) {
-        fbxmat.normalTexture = getHFMTexture(_file.textures[material.normalTexture]);
-        fbxmat.useNormalMap = true;
+        hfmMat.normalTexture = getHFMTexture(_file.textures[material.normalTexture]);
+        hfmMat.useNormalMap = true;
     }
     
     if (material.defined["occlusionTexture"]) {
-        fbxmat.occlusionTexture = getHFMTexture(_file.textures[material.occlusionTexture]);
-        fbxmat.useOcclusionMap = true;
+        hfmMat.occlusionTexture = getHFMTexture(_file.textures[material.occlusionTexture]);
+        hfmMat.useOcclusionMap = true;
     }
 
     if (material.defined["pbrMetallicRoughness"]) {
-        fbxmat.isPBSMaterial = true;
-        
+        hfmMat.isPBSMaterial = true;
+
         if (material.pbrMetallicRoughness.defined["metallicFactor"]) {
-            fbxmat.metallic = material.pbrMetallicRoughness.metallicFactor;
+            hfmMat.metallic = material.pbrMetallicRoughness.metallicFactor;
         }
         if (material.pbrMetallicRoughness.defined["baseColorTexture"]) {
-            fbxmat.opacityTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.baseColorTexture]);
-            fbxmat.albedoTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.baseColorTexture]);
-            fbxmat.useAlbedoMap = true;
+            hfmMat.opacityTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.baseColorTexture]);
+            hfmMat.albedoTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.baseColorTexture]);
+            hfmMat.useAlbedoMap = true;
         }
         if (material.pbrMetallicRoughness.defined["metallicRoughnessTexture"]) {
-            fbxmat.roughnessTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.metallicRoughnessTexture]);
-            fbxmat.roughnessTexture.sourceChannel = image::ColorChannel::GREEN;
-            fbxmat.useRoughnessMap = true;
-            fbxmat.metallicTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.metallicRoughnessTexture]);
-            fbxmat.metallicTexture.sourceChannel = image::ColorChannel::BLUE;
-            fbxmat.useMetallicMap = true;
+            hfmMat.roughnessTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.metallicRoughnessTexture]);
+            hfmMat.roughnessTexture.sourceChannel = image::ColorChannel::GREEN;
+            hfmMat.useRoughnessMap = true;
+            hfmMat.metallicTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.metallicRoughnessTexture]);
+            hfmMat.metallicTexture.sourceChannel = image::ColorChannel::BLUE;
+            hfmMat.useMetallicMap = true;
         }
         if (material.pbrMetallicRoughness.defined["roughnessFactor"]) {
-            fbxmat._material->setRoughness(material.pbrMetallicRoughness.roughnessFactor);
+            hfmMat._material->setRoughness(material.pbrMetallicRoughness.roughnessFactor);
         }
         if (material.pbrMetallicRoughness.defined["baseColorFactor"] && 
             material.pbrMetallicRoughness.baseColorFactor.size() == 4) {
-            glm::vec3 dcolor =  glm::vec3(material.pbrMetallicRoughness.baseColorFactor[0], 
-                                          material.pbrMetallicRoughness.baseColorFactor[1], 
-                                          material.pbrMetallicRoughness.baseColorFactor[2]);
-            fbxmat.diffuseColor = dcolor;
-            fbxmat._material->setAlbedo(dcolor);
-            fbxmat._material->setOpacity(material.pbrMetallicRoughness.baseColorFactor[3]);
-        }   
+            glm::vec3 dcolor =
+                glm::vec3(material.pbrMetallicRoughness.baseColorFactor[0], material.pbrMetallicRoughness.baseColorFactor[1],
+                          material.pbrMetallicRoughness.baseColorFactor[2]);
+            hfmMat.diffuseColor = dcolor;
+            hfmMat._material->setAlbedo(dcolor);
+            hfmMat._material->setOpacity(material.pbrMetallicRoughness.baseColorFactor[3]);
+        }
     }
 
 }

--- a/libraries/fbx/src/GLTFSerializer.h
+++ b/libraries/fbx/src/GLTFSerializer.h
@@ -416,21 +416,13 @@ struct GLTFpbrMetallicRoughness {
     }
 };
 
-namespace GLTFMaterialAlphaMode {
-    enum Values {
-        OPAQUE = 0,
-        MASK,
-        BLEND
-    };
-};
-
 struct GLTFMaterial {
     QString name;
     QVector<double> emissiveFactor;
     int emissiveTexture;
     int normalTexture;
     int occlusionTexture;
-    int alphaMode;
+    graphics::MaterialKey::OpacityMapMode alphaMode;
     double alphaCutoff;
     bool doubleSided;
     GLTFpbrMetallicRoughness pbrMetallicRoughness;
@@ -450,6 +442,12 @@ struct GLTFMaterial {
         }
         if (defined["emissiveFactor"]) {
             qCDebug(modelformat) << "emissiveFactor: " << emissiveFactor;
+        }
+        if (defined["alphaMode"]) {
+            qCDebug(modelformat) << "alphaMode: " << alphaMode;
+        }
+        if (defined["alphaCutoff"]) {
+            qCDebug(modelformat) << "alphaCutoff: " << alphaCutoff;
         }
         if (defined["pbrMetallicRoughness"]) {
             pbrMetallicRoughness.dump();
@@ -800,7 +798,7 @@ private:
 
     hifi::ByteArray setGLBChunks(const hifi::ByteArray& data);
     
-    int getMaterialAlphaMode(const QString& type);
+    graphics::MaterialKey::OpacityMapMode getMaterialAlphaMode(const QString& type);
     int getAccessorType(const QString& type);
     int getAnimationSamplerInterpolation(const QString& interpolation);
     int getCameraType(const QString& type);
@@ -854,7 +852,7 @@ private:
     bool doesResourceExist(const QString& url);
 
 
-    void setHFMMaterial(HFMMaterial& fbxmat, const GLTFMaterial& material);
+    void setHFMMaterial(HFMMaterial& hfmMat, const GLTFMaterial& material);
     HFMTexture getHFMTexture(const GLTFTexture& texture);
     void glTFDebugDump();
     void hfmDebugDump(const HFMModel& hfmModel);

--- a/libraries/graphics-scripting/src/graphics-scripting/Forward.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/Forward.h
@@ -65,6 +65,7 @@ namespace scriptable {
      * @property {Mat4|string} texCoordTransform1
      * @property {string} lightmapParams
      * @property {string} materialParams
+     * @property {string} cullFaceMode
      * @property {boolean} defaultFallthrough
      * @property {string} procedural
      */
@@ -99,6 +100,7 @@ namespace scriptable {
         QString lightMap;
         QString scatteringMap;
         std::array<glm::mat4, graphics::Material::NUM_TEXCOORD_TRANSFORMS> texCoordTransforms;
+        QString cullFaceMode;
         bool defaultFallthrough;
         std::unordered_map<uint, bool> propertyFallthroughs; // not actually exposed to script
 

--- a/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
@@ -495,6 +495,11 @@ namespace scriptable {
                 obj.setProperty("materialParams", FALLTHROUGH);
             }
 
+            if (hasPropertyFallthroughs && material.propertyFallthroughs.at(graphics::Material::CULL_FACE_MODE)) {
+                obj.setProperty("cullFaceMode", FALLTHROUGH);
+            } else if (!material.cullFaceMode.isEmpty()) {
+                obj.setProperty("cullFaceMode", material.cullFaceMode);
+            }
         } else if (material.model.toStdString() == graphics::Material::HIFI_SHADER_SIMPLE) {
             obj.setProperty("procedural", material.procedural);
         }

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableModel.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableModel.cpp
@@ -45,6 +45,7 @@ scriptable::ScriptableMaterial& scriptable::ScriptableMaterial::operator=(const 
         occlusionMap = material.occlusionMap;
         lightMap = material.lightMap;
         scatteringMap = material.scatteringMap;
+        cullFaceMode = material.cullFaceMode;
     } else if (model.toStdString() == graphics::Material::HIFI_SHADER_SIMPLE) {
         procedural = material.procedural;
     }
@@ -131,6 +132,8 @@ scriptable::ScriptableMaterial::ScriptableMaterial(const graphics::MaterialPoint
             for (int i = 0; i < graphics::Material::NUM_TEXCOORD_TRANSFORMS; i++) {
                 texCoordTransforms[i] = material->getTexCoordTransform(i);
             }
+
+            cullFaceMode = QString(graphics::MaterialKey::getCullFaceModeName(material->getCullFaceMode()).c_str());
         } else if (model.toStdString() == graphics::Material::HIFI_SHADER_SIMPLE) {
             procedural = material->getProceduralString();
         }

--- a/libraries/graphics/src/graphics/Material.cpp
+++ b/libraries/graphics/src/graphics/Material.cpp
@@ -209,8 +209,7 @@ bool Material::resetOpacityMap() const {
             }
         }
     }
-    auto newious = _key.getOpacityMapMode();
-    if (previous != newious) {
+    if (previous != _key.getOpacityMapMode()) {
         //opacity change detected for this material
         return true;
     }

--- a/libraries/graphics/src/graphics/Material.cpp
+++ b/libraries/graphics/src/graphics/Material.cpp
@@ -27,7 +27,7 @@ const float Material::DEFAULT_ROUGHNESS { 1.0f };
 const float Material::DEFAULT_SCATTERING{ 0.0f };
 const MaterialKey::OpacityMapMode Material::DEFAULT_OPACITY_MAP_MODE{ MaterialKey::OPACITY_MAP_OPAQUE };
 const float Material::DEFAULT_OPACITY_CUTOFF { 0.5f };
-
+const MaterialKey::CullFaceMode Material::DEFAULT_CULL_FACE_MODE { MaterialKey::CULL_BACK };
 
 std::string MaterialKey::getOpacityMapModeName(OpacityMapMode mode) {
     const std::string names[3] = { "OPACITY_MAP_OPAQUE", "OPACITY_MAP_MASK", "OPACITY_MAP_BLEND" };
@@ -38,6 +38,21 @@ bool MaterialKey::getOpacityMapModeFromName(const std::string& modeName, Materia
     for (int i = OPACITY_MAP_OPAQUE; i <= OPACITY_MAP_BLEND; i++) {
         mode = (MaterialKey::OpacityMapMode) i;
         if (modeName == getOpacityMapModeName(mode)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::string MaterialKey::getCullFaceModeName(CullFaceMode mode) {
+    const std::string names[3] = { "CULL_NONE", "CULL_FRONT", "CULL_BACK" };
+    return names[mode];
+}
+
+bool MaterialKey::getCullFaceModeFromName(const std::string& modeName, CullFaceMode& mode) {
+    for (int i = CULL_NONE; i < NUM_CULL_FACE_MODES; i++) {
+        mode = (CullFaceMode)i;
+        if (modeName == getCullFaceModeName(mode)) {
             return true;
         }
     }
@@ -67,6 +82,7 @@ Material::Material(const Material& material) :
     _texcoordTransforms(material._texcoordTransforms),
     _lightmapParams(material._lightmapParams),
     _materialParams(material._materialParams),
+    _cullFaceMode(material._cullFaceMode),
     _textureMaps(material._textureMaps),
     _defaultFallthrough(material._defaultFallthrough),
     _propertyFallthroughs(material._propertyFallthroughs)
@@ -89,6 +105,7 @@ Material& Material::operator=(const Material& material) {
     _texcoordTransforms = material._texcoordTransforms;
     _lightmapParams = material._lightmapParams;
     _materialParams = material._materialParams;
+    _cullFaceMode = material._cullFaceMode;
     _textureMaps = material._textureMaps;
 
     _defaultFallthrough = material._defaultFallthrough;
@@ -144,7 +161,7 @@ void Material::setOpacityMapMode(MaterialKey::OpacityMapMode opacityMapMode) {
     _key.setOpacityMapMode(opacityMapMode);
 }
 
-MaterialKey::OpacityMapMode  Material::getOpacityMapMode() const {
+MaterialKey::OpacityMapMode Material::getOpacityMapMode() const {
     return _key.getOpacityMapMode();
 }
 

--- a/libraries/graphics/src/graphics/Material.h
+++ b/libraries/graphics/src/graphics/Material.h
@@ -83,6 +83,16 @@ public:
     // find the enum value from a string, return true if match found
     static bool getOpacityMapModeFromName(const std::string& modeName, OpacityMapMode& mode);
 
+    enum CullFaceMode {
+        CULL_NONE = 0,
+        CULL_FRONT,
+        CULL_BACK,
+
+        NUM_CULL_FACE_MODES
+    };
+    static std::string getCullFaceModeName(CullFaceMode mode);
+    static bool getCullFaceModeFromName(const std::string& modeName, CullFaceMode& mode);
+
     // The signature is the Flags
     Flags _flags;
 
@@ -349,6 +359,10 @@ public:
     void setOpacityCutoff(float opacityCutoff);
     float getOpacityCutoff() const { return _opacityCutoff; }
 
+    static const MaterialKey::CullFaceMode DEFAULT_CULL_FACE_MODE;
+    void setCullFaceMode(MaterialKey::CullFaceMode cullFaceMode) { _cullFaceMode = cullFaceMode; }
+    MaterialKey::CullFaceMode getCullFaceMode() const { return _cullFaceMode; }
+
     void setUnlit(bool value);
     bool isUnlit() const { return _key.isUnlit(); }
 
@@ -403,6 +417,7 @@ public:
         TEXCOORDTRANSFORM1,
         LIGHTMAP_PARAMS,
         MATERIAL_PARAMS,
+        CULL_FACE_MODE,
 
         NUM_TOTAL_FLAGS
     };
@@ -436,6 +451,7 @@ private:
     std::array<glm::mat4, NUM_TEXCOORD_TRANSFORMS> _texcoordTransforms;
     glm::vec2 _lightmapParams { 0.0, 1.0 };
     glm::vec2 _materialParams { 0.0, 1.0 };
+    MaterialKey::CullFaceMode _cullFaceMode { DEFAULT_CULL_FACE_MODE };
     TextureMaps _textureMaps;
 
     bool _defaultFallthrough { false };
@@ -524,6 +540,9 @@ public:
     graphics::MaterialKey getMaterialKey() const { return graphics::MaterialKey(_schemaBuffer.get<graphics::MultiMaterial::Schema>()._key); }
     const gpu::TextureTablePointer& getTextureTable() const { return _textureTable; }
 
+    void setCullFaceMode(graphics::MaterialKey::CullFaceMode cullFaceMode) { _cullFaceMode = cullFaceMode; }
+    graphics::MaterialKey::CullFaceMode getCullFaceMode() const { return _cullFaceMode; }
+
     void setNeedsUpdate(bool needsUpdate) { _needsUpdate = needsUpdate; }
     void setTexturesLoading(bool value) { _texturesLoading = value; }
     void setInitialized() { _initialized = true; }
@@ -536,6 +555,7 @@ public:
 
 private:
     gpu::BufferView _schemaBuffer;
+    graphics::MaterialKey::CullFaceMode _cullFaceMode { graphics::Material::DEFAULT_CULL_FACE_MODE };
     gpu::TextureTablePointer _textureTable { std::make_shared<gpu::TextureTable>() };
     bool _needsUpdate { false };
     bool _texturesLoading { false };

--- a/libraries/graphics/src/graphics/MaterialTextures.slh
+++ b/libraries/graphics/src/graphics/MaterialTextures.slh
@@ -223,10 +223,13 @@ vec3 fetchLightMap(vec2 uv) {
 }
 <@endfunc@>
 
-<@func evalMaterialOpacity(fetchedOpacity, materialOpacity, opacity)@>
+<@func evalMaterialOpacity(fetchedOpacity, materialOpacityCutoff, materialOpacity, matKey, opacity)@>
 {
     // This path only valid for transparent material
-    <$opacity$> = <$materialOpacity$> * <$fetchedOpacity$>;
+    <$opacity$> = mix(<$fetchedOpacity$>,
+                          step(<$materialOpacityCutoff$>, <$fetchedOpacity$>),
+                          float((<$matKey$> & OPACITY_MASK_MAP_BIT) != 0))
+                       * <$materialOpacity$>;
 }
 <@endfunc@>
 

--- a/libraries/graphics/src/graphics/MaterialTextures.slh
+++ b/libraries/graphics/src/graphics/MaterialTextures.slh
@@ -223,13 +223,10 @@ vec3 fetchLightMap(vec2 uv) {
 }
 <@endfunc@>
 
-<@func evalMaterialOpacity(fetchedOpacity, materialOpacityCutoff, materialOpacity, matKey, opacity)@>
+<@func evalMaterialOpacity(fetchedOpacity, materialOpacity, opacity)@>
 {
     // This path only valid for transparent material
-    <$opacity$> = mix(<$fetchedOpacity$>,
-                          step(<$materialOpacityCutoff$>, <$fetchedOpacity$>),
-                          float((<$matKey$> & OPACITY_MASK_MAP_BIT) != 0))
-                       * <$materialOpacity$>;
+    <$opacity$> = <$materialOpacity$> * <$fetchedOpacity$>;
 }
 <@endfunc@>
 

--- a/libraries/graphics/src/graphics/MaterialTextures.slh
+++ b/libraries/graphics/src/graphics/MaterialTextures.slh
@@ -214,22 +214,19 @@ vec3 fetchLightMap(vec2 uv) {
 }
 <@endfunc@>
 
-<@func evalMaterialOpacityMask(fetchedOpacity, materialOpacityCutoff, opacity)@>
+<@func evalMaterialOpacityMask(fetchedOpacity, materialOpacityCutoff, materialOpacity, matKey, opacity)@>
 {
-    // This path only valid for opaque or texel opaque material 
-    <$opacity$> = step(<$materialOpacityCutoff$>, <$fetchedOpacity$>);
+    // This path only valid for opaque or texel opaque material
+    <$opacity$> = mix(<$materialOpacity$>,
+                      step(<$materialOpacityCutoff$>, <$fetchedOpacity$>),
+                      float((<$matKey$> & OPACITY_MASK_MAP_BIT) != 0));
 }
 <@endfunc@>
 
-
-<@func evalMaterialOpacity(fetchedOpacity, materialOpacityCutoff, materialOpacity, matKey, opacity)@>
+<@func evalMaterialOpacity(fetchedOpacity, materialOpacity, opacity)@>
 {
     // This path only valid for transparent material
-    // Assert that float((<$matKey$> & (OPACITY_TRANSLUCENT_MAP_BIT | OPACITY_MASK_MAP_BIT)) != 0)) == 1.0
-    <$opacity$> = mix(<$fetchedOpacity$>,
-                          step(<$materialOpacityCutoff$>, <$fetchedOpacity$>),
-                          float((<$matKey$> & OPACITY_MASK_MAP_BIT) != 0))
-                       * <$materialOpacity$>;
+    <$opacity$> = <$materialOpacity$> * <$fetchedOpacity$>;
 }
 <@endfunc@>
 

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -173,23 +173,26 @@ public:
     void getTextureNames(QSet<QString>& textureList) const;
     void setMaxNumPixelsPerTexture(int maxNumPixels);
 
-    glm::vec3 diffuseColor{ 1.0f };
-    float diffuseFactor{ 1.0f };
-    glm::vec3 specularColor{ 0.02f };
-    float specularFactor{ 1.0f };
+    glm::vec3 diffuseColor { 1.0f };
+    float diffuseFactor { 1.0f };
+    glm::vec3 specularColor { 0.02f };
+    float specularFactor { 1.0f };
 
-    glm::vec3 emissiveColor{ 0.0f };
-    float emissiveFactor{ 0.0f };
+    glm::vec3 emissiveColor { 0.0f };
+    float emissiveFactor { 0.0f };
 
-    float shininess{ 23.0f };
-    float opacity{ 1.0f };
+    float shininess { 23.0f };
+    float opacity { 1.0f };
 
-    float metallic{ 0.0f };
-    float roughness{ 1.0f };
-    float emissiveIntensity{ 1.0f };
-    float ambientFactor{ 1.0f };
+    float metallic { 0.0f };
+    float roughness { 1.0f };
+    float emissiveIntensity { 1.0f };
+    float ambientFactor { 1.0f };
 
     float bumpMultiplier { 1.0f }; // TODO: to be implemented
+
+    graphics::MaterialKey::OpacityMapMode alphaMode { graphics::MaterialKey::OPACITY_MAP_BLEND };
+    float alphaCutoff { 0.5f };
 
     QString materialID;
     QString name;
@@ -207,19 +210,19 @@ public:
     Texture occlusionTexture;
     Texture scatteringTexture;
     Texture lightmapTexture;
-    glm::vec2 lightmapParams{ 0.0f, 1.0f };
+    glm::vec2 lightmapParams { 0.0f, 1.0f };
 
 
-    bool isPBSMaterial{ false };
+    bool isPBSMaterial { false };
     // THe use XXXMap are not really used to drive which map are going or not, debug only
-    bool useNormalMap{ false };
-    bool useAlbedoMap{ false };
-    bool useOpacityMap{ false };
-    bool useRoughnessMap{ false };
-    bool useSpecularMap{ false };
-    bool useMetallicMap{ false };
-    bool useEmissiveMap{ false };
-    bool useOcclusionMap{ false };
+    bool useNormalMap { false };
+    bool useAlbedoMap { false };
+    bool useOpacityMap { false };
+    bool useRoughnessMap { false };
+    bool useSpecularMap { false };
+    bool useMetallicMap { false };
+    bool useEmissiveMap { false };
+    bool useOcclusionMap { false };
 
     bool needTangentSpace() const;
 };

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -37,7 +37,7 @@ const unsigned short DEFAULT_DOMAIN_SERVER_PORT =
     .contains("HIFI_DOMAIN_SERVER_PORT")
         ? QProcessEnvironment::systemEnvironment()
             .value("HIFI_DOMAIN_SERVER_PORT")
-            .toShort()
+            .toUShort()
         : 40102;
 
 const unsigned short DEFAULT_DOMAIN_SERVER_DTLS_PORT = 
@@ -45,7 +45,7 @@ const unsigned short DEFAULT_DOMAIN_SERVER_DTLS_PORT =
     .contains("HIFI_DOMAIN_SERVER_DTLS_PORT")
         ? QProcessEnvironment::systemEnvironment()
             .value("HIFI_DOMAIN_SERVER_DTLS_PORT")
-            .toShort()
+            .toUShort()
         : 40103;
 
 const quint16 DOMAIN_SERVER_HTTP_PORT = 
@@ -53,7 +53,7 @@ const quint16 DOMAIN_SERVER_HTTP_PORT =
     .contains("HIFI_DOMAIN_SERVER_HTTP_PORT")
         ? QProcessEnvironment::systemEnvironment()
             .value("HIFI_DOMAIN_SERVER_HTTP_PORT")
-            .toShort()
+            .toUInt()
         : 40100;
 
 const quint16 DOMAIN_SERVER_HTTPS_PORT = 
@@ -61,7 +61,7 @@ const quint16 DOMAIN_SERVER_HTTPS_PORT =
     .contains("HIFI_DOMAIN_SERVER_HTTPS_PORT")
         ? QProcessEnvironment::systemEnvironment()
             .value("HIFI_DOMAIN_SERVER_HTTPS_PORT")
-            .toShort()
+            .toUInt()
         : 40101;
 
 const int MAX_SILENT_DOMAIN_SERVER_CHECK_INS = 5;

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -12,6 +12,8 @@
 #ifndef hifi_DomainHandler_h
 #define hifi_DomainHandler_h
 
+#include <QProcessEnvironment>
+
 #include <QtCore/QJsonObject>
 #include <QtCore/QObject>
 #include <QtCore/QTimer>
@@ -30,10 +32,37 @@
 #include "ReceivedMessage.h"
 #include "NetworkingConstants.h"
 
-const unsigned short DEFAULT_DOMAIN_SERVER_PORT = 40102;
-const unsigned short DEFAULT_DOMAIN_SERVER_DTLS_PORT = 40103;
-const quint16 DOMAIN_SERVER_HTTP_PORT = 40100;
-const quint16 DOMAIN_SERVER_HTTPS_PORT = 40101;
+const unsigned short DEFAULT_DOMAIN_SERVER_PORT = 
+    QProcessEnvironment::systemEnvironment()
+    .contains("HIFI_DOMAIN_SERVER_PORT")
+        ? QProcessEnvironment::systemEnvironment()
+            .value("HIFI_DOMAIN_SERVER_PORT")
+            .toShort()
+        : 40102;
+
+const unsigned short DEFAULT_DOMAIN_SERVER_DTLS_PORT = 
+    QProcessEnvironment::systemEnvironment()
+    .contains("HIFI_DOMAIN_SERVER_DTLS_PORT")
+        ? QProcessEnvironment::systemEnvironment()
+            .value("HIFI_DOMAIN_SERVER_DTLS_PORT")
+            .toShort()
+        : 40103;
+
+const quint16 DOMAIN_SERVER_HTTP_PORT = 
+    QProcessEnvironment::systemEnvironment()
+    .contains("HIFI_DOMAIN_SERVER_HTTP_PORT")
+        ? QProcessEnvironment::systemEnvironment()
+            .value("HIFI_DOMAIN_SERVER_HTTP_PORT")
+            .toShort()
+        : 40100;
+
+const quint16 DOMAIN_SERVER_HTTPS_PORT = 
+    QProcessEnvironment::systemEnvironment()
+    .contains("HIFI_DOMAIN_SERVER_HTTPS_PORT")
+        ? QProcessEnvironment::systemEnvironment()
+            .value("HIFI_DOMAIN_SERVER_HTTPS_PORT")
+            .toShort()
+        : 40101;
 
 const int MAX_SILENT_DOMAIN_SERVER_CHECK_INS = 5;
 

--- a/libraries/procedural/src/procedural/ProceduralCommon.slh
+++ b/libraries/procedural/src/procedural/ProceduralCommon.slh
@@ -60,6 +60,17 @@ LAYOUT_STD140(binding=PROCEDURAL_BUFFER_INPUTS) uniform standardInputsBuffer {
 #define iChannelResolution standardInputs.channelResolution
 #define iWorldOrientation standardInputs.worldOrientation
 
+struct ProceduralVertexData {
+    vec4 position;
+    vec4 nonSkinnedPosition;    // input only
+    vec3 normal;
+    vec3 nonSkinnedNormal;      // input only
+    vec3 tangent;               // input only
+    vec3 nonSkinnedTangent;     // input only
+    vec4 color;
+    vec2 texCoord0;
+};
+
 struct ProceduralFragment {
     vec3 normal;
     vec3 diffuse;

--- a/libraries/procedural/src/procedural/ProceduralMaterialCache.cpp
+++ b/libraries/procedural/src/procedural/ProceduralMaterialCache.cpp
@@ -143,13 +143,20 @@ NetworkMaterialResource::ParsedMaterials NetworkMaterialResource::parseJSONMater
  * @property {string} opacityMap - The URL of the opacity texture image. Set the value the same as the <code>albedoMap</code> 
  *     value for transparency. 
  *     <code>"hifi_pbr"</code> model only.
- * @property {number|string} opacityMapMode - The mode defining the interpretation of the opacity map. Values can be:
+ * @property {string} opacityMapMode - The mode defining the interpretation of the opacity map. Values can be:
  *     <code>"OPACITY_MAP_OPAQUE"</code> for ignoring the opacity map information.
  *     <code>"OPACITY_MAP_MASK"</code> for using the opacity map as a mask, where only the texel greater than opacityCutoff are visible and rendered opaque.
  *     <code>"OPACITY_MAP_BLEND"</code> for using the opacity map for alpha blending the material surface with the background.
  *     Set to <code>"fallthrough"</code> to fall through to the material below. <code>"hifi_pbr"</code> model only.
  * @property {number|string} opacityCutoff - The opacity cutoff threshold used to determine the opaque texels of the Opacity map
  *     when opacityMapMode is "OPACITY_MAP_MASK", range <code>0.0</code> &ndash; <code>1.0</code>.
+ *     Set to <code>"fallthrough"</code> to fall through to the material below. <code>"hifi_pbr"</code> model only.
+ * @property {string} cullFaceMode - The mode defining which side of the geometry should be rendered. Values can be:
+ *     <ul>
+ *         <li><code>"CULL_NONE"</code> for rendering both sides of the geometry.</li>
+ *         <li><code>"CULL_FRONT"</code> for culling the front faces of the geometry.</li>
+ *         <li><code>"CULL_BACK"</code> (the default) for culling the back faces of the geometry.</li>
+ *     </ul>
  *     Set to <code>"fallthrough"</code> to fall through to the material below. <code>"hifi_pbr"</code> model only.
  * @property {string} roughnessMap - The URL of the roughness texture image. You can use this or <code>glossMap</code>, but not 
  *     both. 
@@ -285,7 +292,20 @@ std::pair<std::string, std::shared_ptr<NetworkMaterial>> NetworkMaterialResource
                 } else if (value.isDouble()) {
                     material->setOpacityCutoff(value.toDouble());
                 }
-            } else if (key == "scattering") {
+            } else if (key == "cullFaceMode") {
+                auto value = materialJSON.value(key);
+                if (value.isString()) {
+                    auto valueString = value.toString();
+                    if (valueString == FALLTHROUGH) {
+                        material->setPropertyDoesFallthrough(graphics::Material::ExtraFlagBit::CULL_FACE_MODE);
+                    } else {
+                        graphics::MaterialKey::CullFaceMode mode;
+                        if (graphics::MaterialKey::getCullFaceModeFromName(valueString.toStdString(), mode)) {
+                            material->setCullFaceMode(mode);
+                        }
+                    }
+                }
+           } else if (key == "scattering") {
                 auto value = materialJSON.value(key);
                 if (value.isString() && value.toString() == FALLTHROUGH) {
                     material->setPropertyDoesFallthrough(graphics::MaterialKey::FlagBit::SCATTERING_VAL_BIT);

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -162,18 +162,19 @@ public:
     static const int UNKNOWN_ID;
 
     // Bind the pipeline and get the state to render static geometry
-    void bindSimpleProgram(gpu::Batch& batch, bool textured = false, bool transparent = false, bool culled = true,
-                                          bool unlit = false, bool depthBias = false, bool isAntiAliased = true, bool forward = false);
+    void bindSimpleProgram(gpu::Batch& batch, bool textured = false, bool transparent = false, bool unlit = false, bool depthBias = false,
+        bool isAntiAliased = true, bool forward = false, graphics::MaterialKey::CullFaceMode cullFaceMode = graphics::MaterialKey::CullFaceMode::CULL_BACK);
     // Get the pipeline to render static geometry
-    static gpu::PipelinePointer getSimplePipeline(bool textured = false, bool transparent = false, bool culled = true,
-                                          bool unlit = false, bool depthBias = false, bool fading = false, bool isAntiAliased = true, bool forward = false);
+    static gpu::PipelinePointer getSimplePipeline(bool textured = false, bool transparent = false, bool unlit = false, bool depthBias = false,
+        bool fading = false, bool isAntiAliased = true, bool forward = false, graphics::MaterialKey::CullFaceMode cullFaceMode = graphics::MaterialKey::CullFaceMode::CULL_BACK);
 
     void bindWebBrowserProgram(gpu::Batch& batch, bool transparent, bool forward);
     gpu::PipelinePointer getWebBrowserProgram(bool transparent, bool forward);
     static std::map<std::pair<bool, bool>, gpu::PipelinePointer> _webPipelines;
 
     static void initializeShapePipelines();
-    render::ShapePipelinePointer getShapePipelinePointer(bool transparent, bool unlit, bool forward) { return _shapePipelines[std::make_tuple(transparent, unlit, forward)]; }
+    render::ShapePipelinePointer getShapePipelinePointer(bool transparent, bool unlit, bool forward,
+        graphics::MaterialKey::CullFaceMode cullFaceMode = graphics::MaterialKey::CULL_BACK) { return _shapePipelines[std::make_tuple(transparent, unlit, forward, cullFaceMode)]; }
 
     // Static (instanced) geometry
     void renderShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer);
@@ -456,13 +457,13 @@ private:
     static gpu::ShaderPointer _forwardSimpleFadeShader;
     static gpu::ShaderPointer _forwardUnlitFadeShader;
 
-    static std::map<std::tuple<bool, bool, bool>, render::ShapePipelinePointer> _shapePipelines;
+    static std::map<std::tuple<bool, bool, bool, graphics::MaterialKey::CullFaceMode>, render::ShapePipelinePointer> _shapePipelines;
     static QHash<SimpleProgramKey, gpu::PipelinePointer> _simplePrograms;
 
-    static render::ShapePipelinePointer getShapePipeline(bool textured = false, bool transparent = false, bool culled = true,
-        bool unlit = false, bool depthBias = false, bool forward = false);
-    static render::ShapePipelinePointer getFadingShapePipeline(bool textured = false, bool transparent = false, bool culled = true,
-        bool unlit = false, bool depthBias = false, bool forward = false);
+    static render::ShapePipelinePointer getShapePipeline(bool textured = false, bool transparent = false, bool unlit = false,
+        bool depthBias = false, bool forward = false, graphics::MaterialKey::CullFaceMode cullFaceMode = graphics::MaterialKey::CullFaceMode::CULL_BACK);
+    static render::ShapePipelinePointer getFadingShapePipeline(bool textured = false, bool transparent = false, bool unlit = false,
+        bool depthBias = false, bool forward = false, graphics::MaterialKey::CullFaceMode cullFaceMode = graphics::MaterialKey::CullFaceMode::CULL_BACK);
 };
 
 #endif // hifi_GeometryCache_h

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -143,6 +143,9 @@ ShapeKey MeshPartPayload::getShapeKey() const {
         if (drawMaterialKey.isUnlit()) {
             builder.withUnlit();
         }
+        if (material) {
+            builder.withCullFaceMode(material->getCullFaceMode());
+        }
     }
 
     return builder.build();
@@ -433,6 +436,9 @@ void ModelMeshPartPayload::setShapeKey(bool invalidateShapeKey, PrimitiveMode pr
         }
         if (isUnlit) {
             builder.withUnlit();
+        }
+        if (material) {
+            builder.withCullFaceMode(material->getCullFaceMode());
         }
     }
 

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -110,6 +110,13 @@ ItemKey MeshPartPayload::getKey() const {
 }
 
 Item::Bound MeshPartPayload::getBound() const {
+    graphics::MaterialPointer material = _drawMaterials.empty() ? nullptr : _drawMaterials.top().material;
+    if (material && material->isProcedural() && material->isReady()) {
+        auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(_drawMaterials.top().material);
+        if (procedural->hasVertexShader() && procedural->hasBoundOperator()) {
+           return procedural->getBound();
+        }
+    }
     return _worldBound;
 }
 
@@ -175,6 +182,9 @@ void MeshPartPayload::render(RenderArgs* args) {
 
     if (!_drawMaterials.empty() && _drawMaterials.top().material && _drawMaterials.top().material->isProcedural() &&
             _drawMaterials.top().material->isReady()) {
+        if (!(enableMaterialProceduralShaders && ENABLE_MATERIAL_PROCEDURAL_SHADERS)) {
+            return;
+        }
         auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(_drawMaterials.top().material);
         auto& schema = _drawMaterials.getSchemaBuffer().get<graphics::MultiMaterial::Schema>();
         glm::vec4 outColor = glm::vec4(ColorUtils::tosRGBVec3(schema._albedo), schema._opacity);

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -189,7 +189,7 @@ void MeshPartPayload::render(RenderArgs* args) {
 
     if (!_drawMaterials.empty() && _drawMaterials.top().material && _drawMaterials.top().material->isProcedural() &&
             _drawMaterials.top().material->isReady()) {
-        if (!(enableMaterialProceduralShaders && ENABLE_MATERIAL_PROCEDURAL_SHADERS)) {
+        if (!enableMaterialProceduralShaders) {
             return;
         }
         auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(_drawMaterials.top().material);

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -102,6 +102,10 @@ void MeshPartPayload::updateKey(const render::ItemKey& key) {
         builder.withTransparent();
     }
 
+    if (_cullWithParent) {
+        builder.withSubMetaCulled();
+    }
+
     _itemKey = builder.build();
 }
 
@@ -381,6 +385,10 @@ void ModelMeshPartPayload::updateKey(const render::ItemKey& key) {
     auto matKey = _drawMaterials.getMaterialKey();
     if (matKey.isTranslucent()) {
         builder.withTransparent();
+    }
+
+    if (_cullWithParent) {
+        builder.withSubMetaCulled();
     }
 
     _itemKey = builder.build();

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -75,9 +75,12 @@ public:
 
     void setCullWithParent(bool value) { _cullWithParent = value; }
 
+    static bool enableMaterialProceduralShaders;
+
 protected:
     render::ItemKey _itemKey{ render::ItemKey::Builder::opaqueShape().build() };
     bool _cullWithParent { false };
+    uint64_t _created;
 };
 
 namespace render {

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -43,7 +43,7 @@ public:
     // Render Item interface
     virtual render::ItemKey getKey() const;
     virtual render::Item::Bound getBound() const;
-    virtual render::ShapeKey getShapeKey() const; // shape interface
+    virtual render::ShapeKey getShapeKey() const;
     virtual void render(RenderArgs* args);
 
     // ModelMeshPartPayload functions to perform render
@@ -73,11 +73,11 @@ public:
     void addMaterial(graphics::MaterialLayer material);
     void removeMaterial(graphics::MaterialPointer material);
 
-    static bool enableMaterialProceduralShaders;
+    void setCullWithParent(bool value) { _cullWithParent = value; }
 
 protected:
     render::ItemKey _itemKey{ render::ItemKey::Builder::opaqueShape().build() };
-    uint64_t _created;
+    bool _cullWithParent { false };
 };
 
 namespace render {
@@ -106,7 +106,7 @@ public:
     void updateTransformForSkinnedMesh(const Transform& renderTransform, const Transform& boundTransform);
 
     // Render Item interface
-    render::ShapeKey getShapeKey() const override; // shape interface
+    render::ShapeKey getShapeKey() const override;
     void render(RenderArgs* args) override;
 
     void setShapeKey(bool invalidateShapeKey, PrimitiveMode primitiveMode, bool useDualQuaternionSkinning);

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1040,7 +1040,7 @@ void Model::renderDebugMeshBoxes(gpu::Batch& batch, bool forward) {
     Transform meshToWorld(meshToWorldMatrix);
     batch.setModelTransform(meshToWorld);
 
-    DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false, false, true, true, forward);
+    DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false, true, true, forward, graphics::MaterialKey::CULL_NONE);
 
     for (auto& meshTriangleSets : _modelSpaceMeshTriangleSets) {
         for (auto &partTriangleSet : meshTriangleSets) {

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -965,9 +965,11 @@ void Model::setCullWithParent(bool cullWithParent) {
         _cullWithParent = cullWithParent;
 
         render::Transaction transaction;
-        foreach(auto item, _modelMeshRenderItemsMap.keys()) {
-            transaction.updateItem<ModelMeshPartPayload>(item, [cullWithParent](ModelMeshPartPayload& data) {
+        auto renderItemsKey = _renderItemKeyGlobalFlags;
+        for(auto item : _modelMeshRenderItemIDs) {
+            transaction.updateItem<ModelMeshPartPayload>(item, [cullWithParent, renderItemsKey](ModelMeshPartPayload& data) {
                 data.setCullWithParent(cullWithParent);
+                data.updateKey(renderItemsKey);
             });
         }
         AbstractViewStateInterface::instance()->getMain3DScene()->enqueueTransaction(transaction);

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -154,7 +154,7 @@ void Model::setOffset(const glm::vec3& offset) {
 }
 
 void Model::calculateTextureInfo() {
-    if (!_hasCalculatedTextureInfo && isLoaded() && getGeometry()->areTexturesLoaded() && !_modelMeshRenderItemsMap.isEmpty()) {
+    if (!_hasCalculatedTextureInfo && isLoaded() && getGeometry()->areTexturesLoaded() && !_modelMeshRenderItems.isEmpty()) {
         size_t textureSize = 0;
         int textureCount = 0;
         bool allTexturesLoaded = true;
@@ -957,6 +957,20 @@ void Model::setCauterized(bool cauterized, const render::ScenePointer& scene) {
             });
         }
         scene->enqueueTransaction(transaction);
+    }
+}
+
+void Model::setCullWithParent(bool cullWithParent) {
+    if (_cullWithParent != cullWithParent) {
+        _cullWithParent = cullWithParent;
+
+        render::Transaction transaction;
+        foreach(auto item, _modelMeshRenderItemsMap.keys()) {
+            transaction.updateItem<ModelMeshPartPayload>(item, [cullWithParent](ModelMeshPartPayload& data) {
+                data.setCullWithParent(cullWithParent);
+            });
+        }
+        AbstractViewStateInterface::instance()->getMain3DScene()->enqueueTransaction(transaction);
     }
 }
 

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -129,6 +129,8 @@ public:
     bool isCauterized() const { return _cauterized; }
     void setCauterized(bool value, const render::ScenePointer& scene);
 
+    void setCullWithParent(bool value);
+
     // Access the current RenderItemKey Global Flags used by the model and applied to the render items  representing the parts of the model.
     const render::ItemKey getRenderItemKeyGlobalFlags() const;
 
@@ -503,6 +505,7 @@ protected:
     //  
     render::ItemKey _renderItemKeyGlobalFlags;
     bool _cauterized { false };
+    bool _cullWithParent { false };
 
     bool shouldInvalidatePayloadShapeKey(int meshIndex);
 

--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -259,46 +259,44 @@ void addPlumberPipeline(ShapePlumber& plumber,
 
     gpu::ShaderPointer program = gpu::Shader::createProgram(programId);
 
-    for (int i = 0; i < 8; i++) {
-        bool isCulled = (i & 1);
-        bool isBiased = (i & 2);
-        bool isWireframed = (i & 4);
+    for (int i = 0; i < 4; i++) {
+        bool isBiased = (i & 1);
+        bool isWireframed = (i & 2);
+        for (int cullFaceMode = graphics::MaterialKey::CullFaceMode::CULL_NONE; cullFaceMode < graphics::MaterialKey::CullFaceMode::NUM_CULL_FACE_MODES; cullFaceMode++) {
+            auto state = std::make_shared<gpu::State>();
+            key.isTranslucent() ? PrepareStencil::testMask(*state) : PrepareStencil::testMaskDrawShape(*state);
 
-        auto state = std::make_shared<gpu::State>();
-        key.isTranslucent() ? PrepareStencil::testMask(*state) : PrepareStencil::testMaskDrawShape(*state);
+            // Depth test depends on transparency
+            state->setDepthTest(true, !key.isTranslucent(), gpu::LESS_EQUAL);
+            state->setBlendFunction(key.isTranslucent(),
+                    gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
+                    gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
 
-        // Depth test depends on transparency
-        state->setDepthTest(true, !key.isTranslucent(), gpu::LESS_EQUAL);
-        state->setBlendFunction(key.isTranslucent(),
-                gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
-                gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
+            ShapeKey::Builder builder(key);
+            builder.withCullFaceMode((graphics::MaterialKey::CullFaceMode)cullFaceMode);
+            state->setCullMode((gpu::State::CullMode)cullFaceMode);
+            if (isWireframed) {
+                builder.withWireframe();
+                state->setFillMode(gpu::State::FILL_LINE);
+            }
+            if (isBiased) {
+                builder.withDepthBias();
+                state->setDepthBias(1.0f);
+                state->setDepthBiasSlopeScale(1.0f);
+            }
 
-        ShapeKey::Builder builder(key);
-        if (!isCulled) {
-            builder.withoutCullFace();
+            auto baseBatchSetter = (forceLightBatchSetter || key.isTranslucent()) ? &lightBatchSetter : &batchSetter;
+            render::ShapePipeline::BatchSetter finalBatchSetter;
+            if (extraBatchSetter) {
+                finalBatchSetter = [baseBatchSetter, extraBatchSetter](const ShapePipeline& pipeline, gpu::Batch& batch, render::Args* args) {
+                    baseBatchSetter(pipeline, batch, args);
+                    extraBatchSetter(pipeline, batch, args);
+                };
+            } else {
+                finalBatchSetter = baseBatchSetter;
+            }
+            plumber.addPipeline(builder.build(), program, state, finalBatchSetter, itemSetter);
         }
-        state->setCullMode(isCulled ? gpu::State::CULL_BACK : gpu::State::CULL_NONE);
-        if (isWireframed) {
-            builder.withWireframe();
-            state->setFillMode(gpu::State::FILL_LINE);
-        }
-        if (isBiased) {
-            builder.withDepthBias();
-            state->setDepthBias(1.0f);
-            state->setDepthBiasSlopeScale(1.0f);
-        }
-
-        auto baseBatchSetter = (forceLightBatchSetter || key.isTranslucent()) ? &lightBatchSetter : &batchSetter;
-        render::ShapePipeline::BatchSetter finalBatchSetter;
-        if (extraBatchSetter) {
-            finalBatchSetter = [baseBatchSetter, extraBatchSetter](const ShapePipeline& pipeline, gpu::Batch& batch, render::Args* args) {
-                baseBatchSetter(pipeline, batch, args);
-                extraBatchSetter(pipeline, batch, args);
-            };
-        } else {
-            finalBatchSetter = baseBatchSetter;
-        }
-        plumber.addPipeline(builder.build(), program, state, finalBatchSetter, itemSetter);
     }
 }
 
@@ -644,6 +642,12 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                         wasSet = true;
                     }
                     break;
+                case graphics::Material::CULL_FACE_MODE:
+                    if (!fallthrough) {
+                        multiMaterial.setCullFaceMode(material->getCullFaceMode());
+                        wasSet = true;
+                    }
+                    break;
                 default:
                     break;
             }
@@ -685,6 +689,8 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
             case graphics::Material::MATERIAL_PARAMS:
                 // these are initialized to the correct default values in Schema()
                 break;
+            case graphics::Material::CULL_FACE_MODE:
+                multiMaterial.setCullFaceMode(graphics::Material::DEFAULT_CULL_FACE_MODE);
             case graphics::MaterialKey::ALBEDO_MAP_BIT:
                 if (schemaKey.isAlbedoMap()) {
                     drawMaterialTextures->setTexture(gr::Texture::MaterialAlbedo, textureCache->getWhiteTexture());

--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -387,8 +387,10 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
     std::call_once(once, [] {
         for (int i = 0; i < graphics::Material::NUM_TOTAL_FLAGS; i++) {
             // The opacity mask/map are derived from the albedo map
+            // FIXME: OPACITY_MAP_MODE_BIT is supposed to support fallthrough
             if (i != graphics::MaterialKey::OPACITY_MASK_MAP_BIT &&
-                    i != graphics::MaterialKey::OPACITY_TRANSLUCENT_MAP_BIT) {
+                    i != graphics::MaterialKey::OPACITY_TRANSLUCENT_MAP_BIT &&
+                    i != graphics::MaterialKey::OPACITY_MAP_MODE_BIT) {
                 allFlags.insert(i);
             }
         }

--- a/libraries/render-utils/src/RenderShadowTask.cpp
+++ b/libraries/render-utils/src/RenderShadowTask.cpp
@@ -61,12 +61,12 @@ void RenderShadowTask::build(JobModel& task, const render::Varying& input, rende
     const auto currentKeyLight = setupOutput.getN<RenderShadowSetup::Output>(4);
     // Fetch and cull the items from the scene
 
-    static const auto shadowCasterReceiverFilter = ItemFilter::Builder::visibleWorldItems().withTypeShape().withOpaque().withoutLayered().withTagBits(tagBits, tagMask);
+    static const auto shadowCasterReceiverFilter = ItemFilter::Builder::visibleWorldItems().withOpaque().withoutLayered().withTagBits(tagBits, tagMask);
 
     const auto fetchInput = FetchSpatialTree::Inputs(shadowCasterReceiverFilter, queryResolution).asVarying();
     const auto shadowSelection = task.addJob<FetchSpatialTree>("FetchShadowTree", fetchInput);
-    const auto selectionInputs = FilterSpatialSelection::Inputs(shadowSelection, shadowCasterReceiverFilter).asVarying();
-    const auto shadowItems = task.addJob<FilterSpatialSelection>("FilterShadowSelection", selectionInputs);
+    const auto selectionInputs = CullSpatialSelection::Inputs(shadowSelection, shadowCasterReceiverFilter).asVarying();
+    const auto shadowItems = task.addJob<CullSpatialSelection>("FilterShadowSelection", selectionInputs, nullptr, true, RenderDetails::SHADOW);
 
     // Cull objects that are not visible in camera view. Hopefully the cull functor only performs LOD culling, not
     // frustum culling or this will make shadow casters out of the camera frustum disappear.

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -103,9 +103,8 @@ void main(void) {
         <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
 
     <@if HIFI_USE_TRANSLUCENT@>
-        float cutoff = getMaterialOpacityCutoff(mat);
         float opacity = getMaterialOpacity(mat) * _color.a;
-        <$evalMaterialOpacity(albedoTex.a, cutoff, opacity, matKey, opacity)$>;
+        <$evalMaterialOpacity(albedoTex.a, opacity, opacity)$>;
         <$discardInvisible(opacity)$>;
     <@else@>
         float cutoff = getMaterialOpacityCutoff(mat);
@@ -155,9 +154,8 @@ void main(void) {
     <@endif@>
 
     <@if HIFI_USE_TRANSLUCENT@>
-        float cutoff = getMaterialOpacityCutoff(mat);
         float opacity = getMaterialOpacity(mat) * _color.a;
-        <$evalMaterialOpacity(albedoTex.a, cutoff, opacity, matKey, opacity)$>;
+        <$evalMaterialOpacity(albedoTex.a, opacity, opacity)$>;
         <$discardInvisible(opacity)$>;
     <@else@>
         float cutoff = getMaterialOpacityCutoff(mat);

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -103,8 +103,9 @@ void main(void) {
         <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
 
     <@if HIFI_USE_TRANSLUCENT@>
+        float cutoff = getMaterialOpacityCutoff(mat);
         float opacity = getMaterialOpacity(mat) * _color.a;
-        <$evalMaterialOpacity(albedoTex.a, opacity, opacity)$>;
+        <$evalMaterialOpacity(albedoTex.a, cutoff, opacity, matKey, opacity)$>;
         <$discardInvisible(opacity)$>;
     <@else@>
         float cutoff = getMaterialOpacityCutoff(mat);
@@ -154,8 +155,9 @@ void main(void) {
     <@endif@>
 
     <@if HIFI_USE_TRANSLUCENT@>
+        float cutoff = getMaterialOpacityCutoff(mat);
         float opacity = getMaterialOpacity(mat) * _color.a;
-        <$evalMaterialOpacity(albedoTex.a, opacity, opacity)$>;
+        <$evalMaterialOpacity(albedoTex.a, cutoff, opacity, matKey, opacity)$>;
         <$discardInvisible(opacity)$>;
     <@else@>
         float cutoff = getMaterialOpacityCutoff(mat);

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -103,14 +103,13 @@ void main(void) {
         <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
 
     <@if HIFI_USE_TRANSLUCENT@>
-        float cutoff = getMaterialOpacityCutoff(mat);
         float opacity = getMaterialOpacity(mat) * _color.a;
-        <$evalMaterialOpacity(albedoTex.a, cutoff, opacity, matKey, opacity)$>;
+        <$evalMaterialOpacity(albedoTex.a, opacity, opacity)$>;
         <$discardInvisible(opacity)$>;
     <@else@>
         float cutoff = getMaterialOpacityCutoff(mat);
         float opacity = 1.0;
-        <$evalMaterialOpacityMask(albedoTex.a, cutoff, opacity)$>;
+        <$evalMaterialOpacityMask(albedoTex.a, cutoff, opacity, matKey, opacity)$>;
         <$discardTransparent(opacity)$>;
     <@endif@>
 
@@ -155,14 +154,13 @@ void main(void) {
     <@endif@>
 
     <@if HIFI_USE_TRANSLUCENT@>
-        float cutoff = getMaterialOpacityCutoff(mat);
         float opacity = getMaterialOpacity(mat) * _color.a;
-        <$evalMaterialOpacity(albedoTex.a, cutoff, opacity, matKey, opacity)$>;
+        <$evalMaterialOpacity(albedoTex.a, opacity, opacity)$>;
         <$discardInvisible(opacity)$>;
     <@else@>
         float cutoff = getMaterialOpacityCutoff(mat);
         float opacity = 1.0;
-        <$evalMaterialOpacityMask(albedoTex.a, cutoff, opacity)$>;
+        <$evalMaterialOpacityMask(albedoTex.a, cutoff, opacity, matKey, opacity)$>;
         <$discardTransparent(opacity)$>;
     <@endif@>
 

--- a/libraries/render-utils/src/simple_procedural.slv
+++ b/libraries/render-utils/src/simple_procedural.slv
@@ -20,9 +20,9 @@
 <@if HIFI_USE_DEFORMED or HIFI_USE_DEFORMEDDQ@>
     <@include MeshDeformer.slh@>
     <@if HIFI_USE_DEFORMED@>
-        <$declareMeshDeformer(1, _SCRIBE_NULL, 1, _SCRIBE_NULL, 1)$>
+        <$declareMeshDeformer(1, 1, 1, _SCRIBE_NULL, 1)$>
     <@else@>
-        <$declareMeshDeformer(1, _SCRIBE_NULL, 1, 1, 1)$>
+        <$declareMeshDeformer(1, 1, 1, 1, 1)$>
     <@endif@>
     <$declareMeshDeformerActivation(1, 1)$>
 <@endif@>
@@ -34,24 +34,56 @@ layout(location=RENDER_UTILS_ATTR_NORMAL_WS) out vec3 _normalWS;
 layout(location=RENDER_UTILS_ATTR_COLOR) out vec4 _color;
 layout(location=RENDER_UTILS_ATTR_TEXCOORD01) out vec4 _texCoord01;
 
+<@include procedural/ProceduralCommon.slh@>
+
+#line 1001
+//PROCEDURAL_BLOCK_BEGIN
+
+void getProceduralVertex(inout ProceduralVertexData proceduralData) {}
+
+//PROCEDURAL_BLOCK_END
+
+#line 2030
 void main(void) {
     vec4 positionMS = inPosition;
     vec3 normalMS = inNormal.xyz;
+    vec3 tangentMS = inTangent.xyz;
+    vec4 color = color_sRGBAToLinear(inColor);
+    vec2 texCoord0 = inTexCoord0.st;
 
 <@if HIFI_USE_DEFORMED or HIFI_USE_DEFORMEDDQ@>
-        evalMeshDeformer(inPosition, positionMS, inNormal.xyz, normalMS,
+        evalMeshDeformer(inPosition, positionMS, inNormal.xyz, normalMS, inTangent.xyz, tangentMS,
                          meshDeformer_doSkinning(_drawCallInfo.y), inSkinClusterIndex, inSkinClusterWeight,
                          meshDeformer_doBlendshape(_drawCallInfo.y), gl_VertexID);
 <@endif@>
 
+#if defined(PROCEDURAL_V1) || defined(PROCEDURAL_V2) || defined(PROCEDURAL_V3)
+    ProceduralVertexData proceduralData = ProceduralVertexData(
+        positionMS,
+        inPosition,
+        normalMS,
+        inNormal.xyz,
+        tangentMS,
+        inTangent.xyz,
+        color,
+        texCoord0
+    );
+
+    getProceduralVertex(proceduralData);
+
+    positionMS = proceduralData.position;
+    normalMS = proceduralData.normal;
+    color = proceduralData.color;
+    texCoord0 = proceduralData.texCoord0;
+#endif
+
     _positionMS = positionMS;
     _normalMS = normalMS;
+    _color = color;
+    _texCoord01 = vec4(texCoord0, 0.0, 0.0);
 
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
     <$transformModelToEyeAndClipPos(cam, obj, positionMS, _positionES, gl_Position)$>
     <$transformModelToWorldDir(cam, obj, normalMS, _normalWS)$>
-
-    _color = color_sRGBAToLinear(inColor);
-    _texCoord01 = vec4(inTexCoord0.st, 0.0, 0.0);
 }

--- a/libraries/render/src/render/CullTask.h
+++ b/libraries/render/src/render/CullTask.h
@@ -100,25 +100,24 @@ namespace render {
     };
 
     class CullSpatialSelection {
-        bool _freezeFrustum{ false }; // initialized by Config
-        bool _justFrozeFrustum{ false };
-        bool _skipCulling{ false };
-        ViewFrustum _frozenFrustum;
     public:
         using Config = CullSpatialSelectionConfig;
         using Inputs = render::VaryingSet2<ItemSpatialTree::ItemSelection, ItemFilter>;
         using JobModel = Job::ModelIO<CullSpatialSelection, Inputs, ItemBounds, Config>;
 
-        CullSpatialSelection(CullFunctor cullFunctor, RenderDetails::Type type) :
-            _cullFunctor{ cullFunctor },
+        CullSpatialSelection(CullFunctor cullFunctor, bool skipCulling, RenderDetails::Type type) :
+            _cullFunctor(cullFunctor),
+            _skipCulling(skipCulling),
             _detailType(type) {}
 
-        CullSpatialSelection(CullFunctor cullFunctor) :
-            _cullFunctor{ cullFunctor } {
-        }
-
         CullFunctor _cullFunctor;
+        bool _skipCulling { false };
         RenderDetails::Type _detailType{ RenderDetails::OTHER };
+
+        bool _freezeFrustum { false }; // initialized by Config
+        bool _justFrozeFrustum { false };
+        bool _overrideSkipCulling { false };
+        ViewFrustum _frozenFrustum;
 
         void configure(const Config& config);
         void run(const RenderContextPointer& renderContext, const Inputs& inputs, ItemBounds& outItems);
@@ -145,15 +144,6 @@ namespace render {
         CullFunctor _cullFunctor;
         RenderDetails::Type _detailType{ RenderDetails::OTHER };
 
-    };
-
-    class FilterSpatialSelection {
-    public:
-        using Inputs = render::VaryingSet2<ItemSpatialTree::ItemSelection, ItemFilter>;
-        using JobModel = Job::ModelIO<FilterSpatialSelection, Inputs, ItemBounds>;
-
-        FilterSpatialSelection() {}
-        void run(const RenderContextPointer& renderContext, const Inputs& inputs, ItemBounds& outItems);
     };
 
     class ApplyCullFunctorOnItemBounds {

--- a/libraries/render/src/render/Item.cpp
+++ b/libraries/render/src/render/Item.cpp
@@ -123,7 +123,11 @@ namespace render {
         if (!payload) {
             return ItemKey::Builder::opaqueShape().withTypeMeta();
         }
-        return payload->getKey();
+        if (payload->overrideSubMetaCulled()) {
+            return ItemKey::Builder(payload->getKey()).withSubMetaCulled();
+        } else {
+            return payload->getKey();
+        }
     }
 
     template <> const ShapeKey shapeGetShapeKey(const PayloadProxyInterface::Pointer& payload) {

--- a/libraries/render/src/render/Item.cpp
+++ b/libraries/render/src/render/Item.cpp
@@ -123,11 +123,7 @@ namespace render {
         if (!payload) {
             return ItemKey::Builder::opaqueShape().withTypeMeta();
         }
-        if (payload->overrideSubMetaCulled()) {
-            return ItemKey::Builder(payload->getKey()).withSubMetaCulled();
-        } else {
-            return payload->getKey();
-        }
+        return payload->getKey();
     }
 
     template <> const ShapeKey shapeGetShapeKey(const PayloadProxyInterface::Pointer& payload) {

--- a/libraries/render/src/render/Item.h
+++ b/libraries/render/src/render/Item.h
@@ -614,7 +614,7 @@ public:
     virtual ShapeKey getShapeKey() = 0;
     virtual Item::Bound getBound() = 0;
     virtual void render(RenderArgs* args) = 0;
-    virtual uint32_t metaFetchMetaSubItems(ItemIDs& subItems) = 0;
+    virtual uint32_t metaFetchMetaSubItems(ItemIDs& subItems) const = 0;
 };
 
 template <> const ItemKey payloadGetKey(const PayloadProxyInterface::Pointer& payload);

--- a/libraries/render/src/render/Item.h
+++ b/libraries/render/src/render/Item.h
@@ -615,12 +615,6 @@ public:
     virtual Item::Bound getBound() = 0;
     virtual void render(RenderArgs* args) = 0;
     virtual uint32_t metaFetchMetaSubItems(ItemIDs& subItems) = 0;
-
-    bool overrideSubMetaCulled() const { return _overrideSubMetaCulled; }
-    void setOverrideSubMetaCulled(bool overrideSubMetaCulled) { _overrideSubMetaCulled = overrideSubMetaCulled; }
-
-protected:
-    bool _overrideSubMetaCulled { false };
 };
 
 template <> const ItemKey payloadGetKey(const PayloadProxyInterface::Pointer& payload);
@@ -631,7 +625,7 @@ template <> const ShapeKey shapeGetShapeKey(const PayloadProxyInterface::Pointer
 
 
 typedef Item::PayloadPointer PayloadPointer;
-typedef std::vector< PayloadPointer > Payloads;
+typedef std::vector<PayloadPointer> Payloads;
 
 // A map of items by ShapeKey to optimize rendering pipeline assignments
 using ShapeBounds = std::unordered_map<ShapeKey, ItemBounds, ShapeKey::Hash, ShapeKey::KeyEqual>;

--- a/libraries/render/src/render/Item.h
+++ b/libraries/render/src/render/Item.h
@@ -614,7 +614,13 @@ public:
     virtual ShapeKey getShapeKey() = 0;
     virtual Item::Bound getBound() = 0;
     virtual void render(RenderArgs* args) = 0;
-    virtual uint32_t metaFetchMetaSubItems(ItemIDs& subItems) const = 0;
+    virtual uint32_t metaFetchMetaSubItems(ItemIDs& subItems) = 0;
+
+    bool overrideSubMetaCulled() const { return _overrideSubMetaCulled; }
+    void setOverrideSubMetaCulled(bool overrideSubMetaCulled) { _overrideSubMetaCulled = overrideSubMetaCulled; }
+
+protected:
+    bool _overrideSubMetaCulled { false };
 };
 
 template <> const ItemKey payloadGetKey(const PayloadProxyInterface::Pointer& payload);

--- a/libraries/render/src/render/RenderFetchCullSortTask.cpp
+++ b/libraries/render/src/render/RenderFetchCullSortTask.cpp
@@ -27,7 +27,7 @@ void RenderFetchCullSortTask::build(JobModel& task, const Varying& input, Varyin
     const auto fetchInput = FetchSpatialTree::Inputs(filter, glm::ivec2(0,0)).asVarying();
     const auto spatialSelection = task.addJob<FetchSpatialTree>("FetchSceneSelection", fetchInput);
     const auto cullInputs = CullSpatialSelection::Inputs(spatialSelection, spatialFilter).asVarying();
-    const auto culledSpatialSelection = task.addJob<CullSpatialSelection>("CullSceneSelection", cullInputs, cullFunctor, RenderDetails::ITEM);
+    const auto culledSpatialSelection = task.addJob<CullSpatialSelection>("CullSceneSelection", cullInputs, cullFunctor, false, RenderDetails::ITEM);
 
     // Layered objects are not culled
     const ItemFilter layeredFilter = ItemFilter::Builder::visibleWorldItems().withTagBits(tagBits, tagMask);


### PR DESCRIPTION
This PR merges in 5 separate PRs:
- https://github.com/highfidelity/hifi/pull/16499 (Procedural Vertex Shaders)
- https://github.com/highfidelity/hifi/pull/16528 (Support GLTF alphaModes and fix opacityMapModes)
- https://github.com/highfidelity/hifi/pull/16546 (Material Entities can specify face culling method, support GLTF doubleSided property)
- https://github.com/highfidelity/hifi/pull/16548 (Case 17368: Fix wearables not disappearing with avatar)
- https://github.com/highfidelity/hifi/pull/16509 (Added environment variables to change domain server ports) (This is a server change, this may be tested at a later time)

This was successfully built on:
Windows 10 Pro 1903 (18362.476)
CMake 3.15, Visual Studio 2019