### PR TITLE
Update SDL2 CONTROL file to fix linux build

### DIFF
--- a/cmake/ports/sdl2/CONTROL
+++ b/cmake/ports/sdl2/CONTROL
@@ -1,6 +1,6 @@
 Source: sdl2
 Version: 2.0.10-2
-Homepage: https://github.com/SDL-Mirror/SDL
+
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
 
 Feature: vulkan


### PR DESCRIPTION
This fixes a build error when building the SDL2 library from vcpkg. Apparently, vcpkg on Linux doesn't like the `Homepage' entry.