### PR TITLE
Redo graphics presets

### DIFF
--- a/interface/resources/qml/hifi/dialogs/graphics/GraphicsSettings.qml
+++ b/interface/resources/qml/hifi/dialogs/graphics/GraphicsSettings.qml
@@ -53,6 +53,20 @@ Item {
                 spacing: 0
 
                 HifiControlsUit.RadioButton {
+                    id: performanceEco
+                    colorScheme: hifi.colorSchemes.dark
+                    height: 18
+                    fontSize: 16
+                    leftPadding: 0
+                    text: "Battery saver"
+                    checked: Performance.getPerformancePreset() === PerformanceEnums.ECO
+                    onClicked: {
+                        Performance.setPerformancePreset(PerformanceEnums.ECO);
+                        root.refreshAllDropdowns();
+                    }
+                }
+
+                HifiControlsUit.RadioButton {
                     id: performanceLow
                     colorScheme: hifi.colorSchemes.dark
                     height: 18

--- a/interface/resources/qml/hifi/dialogs/graphics/GraphicsSettings.qml
+++ b/interface/resources/qml/hifi/dialogs/graphics/GraphicsSettings.qml
@@ -59,9 +59,9 @@ Item {
                     fontSize: 16
                     leftPadding: 0
                     text: "Battery saver"
-                    checked: Performance.getPerformancePreset() === PerformanceEnums.ECO
+                    checked: Performance.getPerformancePreset() === PerformanceEnums.BATT
                     onClicked: {
-                        Performance.setPerformancePreset(PerformanceEnums.ECO);
+                        Performance.setPerformancePreset(PerformanceEnums.BATT);
                         root.refreshAllDropdowns();
                     }
                 }

--- a/interface/resources/qml/hifi/simplifiedUI/settingsApp/general/General.qml
+++ b/interface/resources/qml/hifi/simplifiedUI/settingsApp/general/General.qml
@@ -177,9 +177,9 @@ Flickable {
                 SimplifiedControls.RadioButton {
                     id: performanceEco
                     text: "Battery Saver"
-                    checked: Performance.getPerformancePreset() === PerformanceEnums.ECO
+                    checked: Performance.getPerformancePreset() === PerformanceEnums.BATT
                     onClicked: {
-                        Performance.setPerformancePreset(PerformanceEnums.ECO);
+                        Performance.setPerformancePreset(PerformanceEnums.BATT);
                     }
                 }
 

--- a/interface/resources/qml/hifi/simplifiedUI/settingsApp/general/General.qml
+++ b/interface/resources/qml/hifi/simplifiedUI/settingsApp/general/General.qml
@@ -175,6 +175,15 @@ Flickable {
                 spacing: simplifiedUI.margins.settings.spacingBetweenRadiobuttons
 
                 SimplifiedControls.RadioButton {
+                    id: performanceEco
+                    text: "Battery Saver"
+                    checked: Performance.getPerformancePreset() === PerformanceEnums.ECO
+                    onClicked: {
+                        Performance.setPerformancePreset(PerformanceEnums.ECO);
+                    }
+                }
+
+                SimplifiedControls.RadioButton {
                     id: performanceLow
                     text: "Low Quality" + (PlatformInfo.getTierProfiled() === PerformanceEnums.LOW ? " (Recommended)" : "")
                     checked: Performance.getPerformancePreset() === PerformanceEnums.LOW

--- a/interface/src/PerformanceManager.cpp
+++ b/interface/src/PerformanceManager.cpp
@@ -117,7 +117,7 @@ void PerformanceManager::applyPerformancePreset(PerformanceManager::PerformanceP
             DependencyManager::get<LODManager>()->setWorldDetailQuality(WORLD_DETAIL_LOW);
 
         break;
-        case PerformancePreset::ECO:
+        case PerformancePreset::BATT:
             RenderScriptingInterface::getInstance()->setRenderMethod(RenderScriptingInterface::RenderMethod::FORWARD);
             RenderScriptingInterface::getInstance()->setShadowsEnabled(false);
             qApp->getRefreshRateManager().setRefreshRateProfile(RefreshRateManager::RefreshRateProfile::ECO);

--- a/interface/src/PerformanceManager.cpp
+++ b/interface/src/PerformanceManager.cpp
@@ -103,11 +103,21 @@ void PerformanceManager::applyPerformancePreset(PerformanceManager::PerformanceP
             RenderScriptingInterface::getInstance()->setViewportResolutionScale(recommandedPpiScale);
 
             RenderScriptingInterface::getInstance()->setShadowsEnabled(false);
-            qApp->getRefreshRateManager().setRefreshRateProfile(RefreshRateManager::RefreshRateProfile::INTERACTIVE);
+            qApp->getRefreshRateManager().setRefreshRateProfile(RefreshRateManager::RefreshRateProfile::REALTIME);
             DependencyManager::get<LODManager>()->setWorldDetailQuality(WORLD_DETAIL_MEDIUM);
 
         break;
         case PerformancePreset::LOW:
+            RenderScriptingInterface::getInstance()->setRenderMethod(RenderScriptingInterface::RenderMethod::FORWARD);
+            RenderScriptingInterface::getInstance()->setShadowsEnabled(false);
+            qApp->getRefreshRateManager().setRefreshRateProfile(RefreshRateManager::RefreshRateProfile::REALTIME);
+
+            RenderScriptingInterface::getInstance()->setViewportResolutionScale(recommandedPpiScale);
+
+            DependencyManager::get<LODManager>()->setWorldDetailQuality(WORLD_DETAIL_LOW);
+
+        break;
+        case PerformancePreset::ECO:
             RenderScriptingInterface::getInstance()->setRenderMethod(RenderScriptingInterface::RenderMethod::FORWARD);
             RenderScriptingInterface::getInstance()->setShadowsEnabled(false);
             qApp->getRefreshRateManager().setRefreshRateProfile(RefreshRateManager::RefreshRateProfile::ECO);

--- a/interface/src/PerformanceManager.h
+++ b/interface/src/PerformanceManager.h
@@ -21,6 +21,7 @@ class PerformanceManager {
 public:
     enum PerformancePreset {
         UNKNOWN = 0, // Matching the platform Tier profiles enumeration for coherence
+        ECO,
         LOW,
         MID,
         HIGH,

--- a/interface/src/PerformanceManager.h
+++ b/interface/src/PerformanceManager.h
@@ -21,7 +21,7 @@ class PerformanceManager {
 public:
     enum PerformancePreset {
         UNKNOWN = 0, // Matching the platform Tier profiles enumeration for coherence
-        ECO,
+        BATT,
         LOW,
         MID,
         HIGH,

--- a/interface/src/scripting/PerformanceScriptingInterface.cpp
+++ b/interface/src/scripting/PerformanceScriptingInterface.cpp
@@ -29,7 +29,7 @@ PerformanceScriptingInterface::PerformancePreset PerformanceScriptingInterface::
 }
 
 QStringList PerformanceScriptingInterface::getPerformancePresetNames() const {
-    static const QStringList performancePresetNames = { "UNKNOWN", "LOW", "MID", "HIGH" };
+    static const QStringList performancePresetNames = { "UNKNOWN", "ECO", "LOW", "MID", "HIGH" };
     return performancePresetNames;
 }
 

--- a/interface/src/scripting/PerformanceScriptingInterface.h
+++ b/interface/src/scripting/PerformanceScriptingInterface.h
@@ -28,6 +28,7 @@ public:
     // PerformanceManager PerformancePreset tri state level enums
     enum PerformancePreset {
         UNKNOWN = PerformanceManager::PerformancePreset::UNKNOWN,
+        BATT = PerformanceManager::PerformancePreset::BATT,
         LOW = PerformanceManager::PerformancePreset::LOW,
         MID = PerformanceManager::PerformancePreset::MID,
         HIGH = PerformanceManager::PerformancePreset::HIGH,


### PR DESCRIPTION
* Add "battery saver" mode, which is the only one that has "economical"
  rendering. This mode will never be selected automatically and must be
  chosen by the user.
* Change all other modes to realtime.

Reasoning:

Whenever interface crashes, it sets the graphics settings to low. This not
only has low detail, but also limited framerate. This may create the impression
that there's something seriously wrong with the rendering engine.

Now the interface will always have the best framerate, except when the user
wishes otherwise.