### PR TITLE
Audio Failure Due to missing VR fix

### DIFF
--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -108,11 +108,11 @@ QString getVrSettingString(const char* section, const char* setting) {
     return result;
 }
 
-bool isHMDConnected = false;
+bool isHMDInErrorState = false;
 
 vr::IVRSystem* acquireOpenVrSystem() {
     bool hmdPresent = vr::VR_IsHmdPresent();
-    if (hmdPresent && (!isHMDConnected)) {
+    if (hmdPresent && !isHMDInErrorState) {
         Lock lock(mutex);
         if (!activeHmd) {
             #if DEV_BUILD
@@ -125,8 +125,8 @@ vr::IVRSystem* acquireOpenVrSystem() {
                 qCDebug(displayplugins) << "OpenVR display: HMD is " << activeHmd << " error is " << eError;
             #endif
 
-            if (eError == 108) { // vr::HmdError_Init_HmdNotFound
-                isHMDConnected = true;
+            if (eError == vr::VRInitError_Init_HmdNotFound) {
+                isHMDInErrorState = true;
                 activeHmd = nullptr;
                 #if DEV_BUILD
                     qCDebug(displayplugins) << "OpenVR: No HMD connected, setting nullptr!";

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -108,11 +108,11 @@ QString getVrSettingString(const char* section, const char* setting) {
     return result;
 }
 
-int headsetNotConnected = -1;
+bool isHMDConnected = false;
 
 vr::IVRSystem* acquireOpenVrSystem() {
     bool hmdPresent = vr::VR_IsHmdPresent();
-    if (hmdPresent && (headsetNotConnected <= 0)) {
+    if (hmdPresent && (!isHMDConnected)) {
         Lock lock(mutex);
         if (!activeHmd) {
             #if DEV_BUILD
@@ -126,7 +126,7 @@ vr::IVRSystem* acquireOpenVrSystem() {
             #endif
 
             if (eError == 108) { // vr::HmdError_Init_HmdNotFound
-                headsetNotConnected = 1;
+                isHMDConnected = true;
                 activeHmd = nullptr;
                 #if DEV_BUILD
                     qCDebug(displayplugins) << "OpenVR: No HMD connected, setting nullptr!";


### PR DESCRIPTION
fixes: [https://github.com/kasenvr/project-athena/issues/27](https://github.com/kasenvr/project-athena/issues/27)

Testing:

1. Close SteamVR.
2. Start Interface.
3. Wait until Interface fully loads.

Expected results:
SteamVR gets opened,
Interface doesn't take forever to load due to SteamVR
Audio still works.