### PR TITLE
Workaround for Secondary camera crash

### DIFF
--- a/libraries/render/src/render/CullTask.cpp
+++ b/libraries/render/src/render/CullTask.cpp
@@ -130,6 +130,10 @@ void FetchSpatialTree::configure(const Config& config) {
 }
 
 void FetchSpatialTree::run(const RenderContextPointer& renderContext, const Inputs& inputs, ItemSpatialTree::ItemSelection& outSelection) {
+    if (!renderContext){
+        return;
+    }
+    
     // start fresh
     outSelection.clear();
 
@@ -141,6 +145,10 @@ void FetchSpatialTree::run(const RenderContextPointer& renderContext, const Inpu
         assert(renderContext->args->hasViewFrustum());
         RenderArgs* args = renderContext->args;
         auto& scene = renderContext->_scene;
+
+        if (!args) {
+            return;
+        }
 
         auto queryFrustum = args->getViewFrustum();
         // Eventually use a frozen frustum


### PR DESCRIPTION
This fixes a possible crash with the secondary camera.

It's a hard one to repro cause it doesn't always happen.

But if you're turning the camera on and off a lot it can crash.