### PR TITLE
Don't bind action if QML menu can't be added.

### DIFF
--- a/libraries/ui/src/VrMenu.cpp
+++ b/libraries/ui/src/VrMenu.cpp
@@ -269,7 +269,11 @@ void VrMenu::insertAction(QAction* before, QAction* action) {
     Q_ASSERT(invokeResult);
     QObject* result = reinterpret_cast<QObject*>(returnedValue); // returnedValue.value<QObject*>();
     Q_ASSERT(result);
-    bindActionToQmlAction(result, action, _rootMenu);
+    if ( result ) {
+        bindActionToQmlAction(result, action, _rootMenu);
+    } else {
+        qWarning() << "Failed to find addItem() method in object " << menu << ". Not inserting action " << action;
+    }
 }
 
 class QQuickMenuBase;


### PR DESCRIPTION
Otherwise eventually methods will be called on a NULL pointer.
Fixes crash related to QMetaObject::invokeMethod.

This patch produces the following warnings:
```

[12/26 00:19:09] [WARNING] [default] Failed to find addItem() method in object  QQmlComponent(0x1b9b0270) . Not inserting action  QAction(0x1d228520 text="Undo" toolTip="Undo" shortcut=QKeySequence("Ctrl+Z") menuRole=TextHeuristicRole visible=true)
[12/26 00:19:09] [WARNING] [default] Failed to find addItem() method in object  QQmlComponent(0x1b9b0270) . Not inserting action  QAction(0x7efbdc009580 text="Redo" toolTip="Redo" shortcut=QKeySequence("Ctrl+Y") menuRole=TextHeuristicRole visible=true)
[12/26 00:19:09] [WARNING] [default] Failed to find addItem() method in object  QQmlComponent(0x1b9b0270) . Not inserting action  QAction(0x7efbdc0082a0 text="Export Entities" toolTip="Export Entities" menuRole=TextHeuristicRole visible=true)
[12/26 00:19:09] [WARNING] [default] Failed to find addItem() method in object  QQmlComponent(0x1b9b0270) . Not inserting action  QAction(0x7ef9a4040630 text="Import Entities" toolTip="Import Entities" menuRole=TextHeuristicRole visible=true)
[12/26 00:19:09] [WARNING] [default] Failed to find addItem() method in object  QQmlComponent(0x1b9b0270) . Not inserting action  QAction(0x1ba9eba0 text="Import Entities from URL" toolTip="Import Entities from URL" menuRole=TextHeuristicRole visible=true)
```

This change just ensures it doesn't crash, but some sort of fix related to those is still needed.
