### PR TITLE
Re-enable JSDoc building

### DIFF
--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -15,9 +15,9 @@ set(CUSTOM_INTERFACE_QRC_PATHS "")
 
 find_npm()
 
-#if (BUILD_TOOLS AND NPM_EXECUTABLE)
-#  add_custom_qrc_path(CUSTOM_INTERFACE_QRC_PATHS "${CMAKE_SOURCE_DIR}/tools/jsdoc/out/hifiJSDoc.json" "auto-complete/hifiJSDoc.json")
-#endif ()
+if (BUILD_TOOLS AND NPM_EXECUTABLE)
+  add_custom_qrc_path(CUSTOM_INTERFACE_QRC_PATHS "${CMAKE_SOURCE_DIR}/tools/jsdoc/out/hifiJSDoc.json" "auto-complete/hifiJSDoc.json")
+endif ()
 
 set(RESOURCES_QRC ${CMAKE_CURRENT_BINARY_DIR}/resources.qrc)
 set(RESOURCES_RCC ${CMAKE_CURRENT_SOURCE_DIR}/compiledResources/resources.rcc)
@@ -182,10 +182,10 @@ else ()
 endif ()
 
 
-#if (BUILD_TOOLS AND NPM_EXECUTABLE)
+if (BUILD_TOOLS AND NPM_EXECUTABLE)
   # require JSDoc to be build before interface is deployed
-#  add_dependencies(resources jsdoc)
-#endif()
+  add_dependencies(resources jsdoc)
+endif()
 
 add_dependencies(${TARGET_NAME} resources)
 
@@ -326,9 +326,9 @@ if (APPLE)
       "${CMAKE_SOURCE_DIR}/scripts"
       "${RESOURCES_DEV_DIR}/scripts"
     # copy JSDoc files beside the executable
-    #COMMAND "${CMAKE_COMMAND}" -E copy_directory
-    #  "${CMAKE_SOURCE_DIR}/tools/jsdoc/out"
-    #  "${RESOURCES_DEV_DIR}/jsdoc"
+    COMMAND "${CMAKE_COMMAND}" -E copy_directory
+      "${CMAKE_SOURCE_DIR}/tools/jsdoc/out"
+      "${RESOURCES_DEV_DIR}/jsdoc"
     # copy the resources files beside the executable
     COMMAND "${CMAKE_COMMAND}" -E copy_if_different
       "${RESOURCES_RCC}"
@@ -381,9 +381,9 @@ else()
       "${PROJECT_SOURCE_DIR}/resources/serverless/redirect.json"
       "${RESOURCES_DEV_DIR}/serverless/redirect.json"
     # copy JSDoc files beside the executable
-    #COMMAND "${CMAKE_COMMAND}" -E copy_directory
-    #  "${CMAKE_SOURCE_DIR}/tools/jsdoc/out"
-    #  "${INTERFACE_EXEC_DIR}/jsdoc"
+    COMMAND "${CMAKE_COMMAND}" -E copy_directory
+      "${CMAKE_SOURCE_DIR}/tools/jsdoc/out"
+      "${INTERFACE_EXEC_DIR}/jsdoc"
   )
 
   # link target to external libraries


### PR DESCRIPTION
API documentation is put in \build\interface\Release\jsdoc directory when Interface is built.