### PR TITLE
Optional SteamVR

### DIFF
--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -117,7 +117,7 @@ vr::IVRSystem* acquireOpenVrSystem() {
                 qCDebug(displayplugins) << "OpenVR: No vr::IVRSystem instance active, building";
             #endif
             vr::EVRInitError eError = vr::VRInitError_None;
-            activeHmd = vr::VR_Init(&eError, vr::VRApplication_Scene);
+            activeHmd = vr::VR_Init(&eError, vr::VRApplication_Background);
 
             #if DEV_BUILD
                 qCDebug(displayplugins) << "OpenVR display: HMD is " << activeHmd << " error is " << eError;


### PR DESCRIPTION
Made Interface not start SteamVR, To use VR you need to start SteamVR first.

Testing:

Start interface without SteamVR running.
Should see no VR icon.
Close interface
Start interface with SteamVR and headset running.
Should see VR icon and VR should work!

