### PR TITLE
Add support for Ubuntu 19.10, modernize vcpkg

### DIFF
--- a/BUILD_LINUX.md
+++ b/BUILD_LINUX.md
@@ -63,9 +63,9 @@ sudo apt-get install libasound2 libxmu-dev libxi-dev freeglut3-dev libasound2-de
 ```bash
 sudo apt-get -y install libpulse0 libnss3 libnspr4 libfontconfig1 libxcursor1 libxcomposite1 libxtst6 libxslt1.1
 ```
-1.  Install Python 3:
+1.  Install Python 3 and required packages
 ```bash
-sudo apt-get install python3.6
+sudo apt-get install python3 python3-distro
 ```
 1.  Install node, required to build the jsdoc documentation
 ```bash

--- a/hifi_utils.py
+++ b/hifi_utils.py
@@ -118,6 +118,6 @@ def downloadAndExtract(url, destPath, hash=None, hasher=hashlib.sha512(), isZip=
             zip.extractall(destPath)
     else:
         # Extract the archive
-        with tarfile.open(tempFileName, 'r:gz') as tgz:
+        with tarfile.open(tempFileName, 'r:*') as tgz:
             tgz.extractall(destPath)
     os.remove(tempFileName)

--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -9,6 +9,7 @@ import tempfile
 import json
 import xml.etree.ElementTree as ET
 import functools
+import distro
 from os import path
 
 print = functools.partial(print, flush=True)
@@ -286,15 +287,32 @@ endif()
             elif platform.system() == 'Darwin':
                 url = self.assets_url + '/dependencies/vcpkg/qt5-install-5.12.3-macos.tar.gz%3FversionId=bLAgnoJ8IMKpqv8NFDcAu8hsyQy3Rwwz'
             elif platform.system() == 'Linux':
-                if platform.linux_distribution()[1][:3] == '16.':
-                    url = self.assets_url + '/dependencies/vcpkg/qt5-install-5.12.3-ubuntu-16.04-with-symbols.tar.gz'
-                elif platform.linux_distribution()[1][:3] == '18.':
-                    url = self.assets_url + '/dependencies/vcpkg/qt5-install-5.12.3-ubuntu-18.04.tar.gz'
+                dist = distro.linux_distribution()
+
+                if distro.id() == 'ubuntu':
+                    u_major = int( distro.major_version() )
+                    u_minor = int( distro.minor_version() )
+
+                    if u_major == 16:
+                        url = self.assets_url + '/dependencies/vcpkg/qt5-install-5.12.3-ubuntu-16.04-with-symbols.tar.gz'
+                    elif u_major == 18:
+                        url = self.assets_url + '/dependencies/vcpkg/qt5-install-5.12.3-ubuntu-18.04.tar.gz'
+                    elif u_major == 19 and u_minor == 10:
+                        url = self.assets_url + '/dependencies/vcpkg/qt5-install-5.12.6-ubuntu-19.10.tar.xz'
+                    elif u_major > 18 and ( u_major != 19 and u_minor != 4):
+                        print("We don't support " + distro.name(pretty=True) + " yet. Perhaps consider helping us out?")
+                    else:
+                        print("Sorry, " + distro.name(pretty=True) + " is old and won't be officially supported. Please consider upgrading.");
                 else:
-                    print('UNKNOWN LINUX VERSION!!!')
+                    print("Sorry, " + distro.name(pretty=True) + " is not supported. Please consider helping us out.")
+                    print("It's also possible to build Qt for your distribution, please see the documentation at:")
+                    print("https://github.com/kasenvr/project-athena/tree/kasen/core/tools/qt-builder")
                     return;
             else:
                 print('UNKNOWN OPERATING SYSTEM!!!')
+                print("System      : " + platform.system())
+                print("Architecture: " + platform.architecture())
+                print("Machine     : " + platform.machine())
                 return;
 
             print('Extracting ' + url + ' to ' + dest)


### PR DESCRIPTION
This PR does several, related things:

* Makes it possible to use packages other than .tar.gz (for instance tar.xz and tar.bz2)
* Removes the usage of the deprecated platform.linux_distribution() functions.
* Adds experimental support for Ubuntu 19.10, by using a package I built and that is already uploaded to athena-public.
* Is a bit friendlier in the error reporting
