### PR TITLE
Fix scaled avatar walk speed

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -3825,7 +3825,7 @@ void MyAvatar::updateActionMotor(float deltaTime) {
         }
         _actionMotorVelocity = motorSpeed * direction;
     } else {
-        _actionMotorVelocity = direction;
+        _actionMotorVelocity = sensorToWorldScale * direction;
     }
 
     float previousBoomLength = _boomLength;


### PR DESCRIPTION
The walk speed of your avatar is now proportional to your avatar's scale: small scales no longer run instead of walk; large scales no longer walk s l o w l y.

Tested:
- Desktop keyboard: walking (fixed), flying.
- Desktop gamepad: walking (fixed), flying.
- HMD walking, flying.

Desktop keyboard and gamepad walking were both broken; both are now fixed.

Issue: https://github.com/kasenvr/project-athena/issues/17