### PR TITLE
Fix generating cmake

### DIFF
--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -164,7 +164,7 @@ endif()
         if downloadVcpkg:
             if "HIFI_VCPKG_BOOTSTRAP" in os.environ:
                 print("Cloning vcpkg from github to {}".format(self.path))
-                hifi_utils.executeSubprocess(['git', 'clone', 'git@github.com:microsoft/vcpkg.git', self.path])
+                hifi_utils.executeSubprocess(['git', 'clone', 'https://github.com/microsoft/vcpkg', self.path])
                 print("Bootstrapping vcpkg")
                 hifi_utils.executeSubprocess([self.bootstrapCmd], folder=self.path)
             else:


### PR DESCRIPTION
vcpkg throws an error when running cmake about a public key error. This resolves the possibility of the error showing up.