### PR TITLE
Whitelist Quality of Life Updates

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -2377,20 +2377,20 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
         // END PULL SAFEURLS FROM INTERFACE.JSON Settings
         
         bool isInWhitelist = false;  // assume unsafe
-		
-		if (ScriptEngine::getContext() == "entity_server") {
-			isInWhitelist = true;
-		} else {
-			for (const auto& str : safeURLS) {
-				qCDebug(scriptengine) << whitelistPrefix << "Script URL: " << scriptOrURL << "TESTING AGAINST" << str << "RESULTS IN"
-					<< scriptOrURL.startsWith(str);
-				if (!str.isEmpty() && scriptOrURL.startsWith(str)) {
-					isInWhitelist = true;
-					qCDebug(scriptengine) << whitelistPrefix << "Script approved.";
-					break; // bail early since we found a match
-				}
-			}
-		}
+
+        if (ScriptEngine::getContext() == "entity_server") {
+            isInWhitelist = true;
+        } else {
+            for (const auto& str : safeURLS) {
+                qCDebug(scriptengine) << whitelistPrefix << "Script URL: " << scriptOrURL << "TESTING AGAINST" << str << "RESULTS IN"
+                    << scriptOrURL.startsWith(str);
+                if (!str.isEmpty() && scriptOrURL.startsWith(str)) {
+                    isInWhitelist = true;
+                    qCDebug(scriptengine) << whitelistPrefix << "Script approved.";
+                    break; // bail early since we found a match
+                }
+            }
+        }
 
         if (!isInWhitelist) {
             qCDebug(scriptengine) << whitelistPrefix << "(disabled entity script)" << entityID.toString() << scriptOrURL;

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -2386,7 +2386,7 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
         QString domainSafeIP = nodeList->getDomainHandler().getHostname();
         QString domainSafeURL = "hifi://" + currentDomain;
         for (const auto& str : safeURLS) {
-            if(domainSafeURL.startsWith(str) || domainSafeIP.startsWith(str)) {
+            if (domainSafeURL.startsWith(str) || domainSafeIP.startsWith(str)) {
                 qCDebug(scriptengine) << whitelistPrefix << "Whitelist Bypassed. Current Domain Host: " 
                     << nodeList->getDomainHandler().getHostname()
                     << "Current Domain: " << currentDomain;
@@ -2396,9 +2396,9 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
         // END CURRENT DOMAIN WHITELIST BYPASS
 
         // START CHECKING AGAINST THE WHITELIST
-        if (ScriptEngine::getContext() == "entity_server" || passList == true) { // If running on the server or waved through, do not engage whitelist.
+        if (ScriptEngine::getContext() == "entity_server") { // If running on the server, do not engage whitelist.
             passList = true;
-        } else {
+        } else if (!passList) { // If waved through, do not engage whitelist.
             for (const auto& str : safeURLS) {
                 qCDebug(scriptengine) << whitelistPrefix << "Script URL: " << scriptOrURL << "TESTING AGAINST" << str << "RESULTS IN"
                     << scriptOrURL.startsWith(str);

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -2363,7 +2363,7 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
         }
     }
     else {
-      // ENTITY SCRIPT WHITELIST STARTS HERE
+		// ENTITY SCRIPT WHITELIST STARTS HERE
         QString whitelistPrefix = "[WHITELIST ENTITY SCRIPTS]";
         QList<QString> safeURLS = { "" };
         safeURLS += qEnvironmentVariable("EXTRA_WHITELIST").trimmed().split(QRegExp("\\s*,\\s*"), QString::SkipEmptyParts);
@@ -2378,16 +2378,16 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
         
         bool isInWhitelist = false;  // assume unsafe
 		
-		if(ScriptEngine::getContext() == "entity_server") {
+		if (ScriptEngine::getContext() == "entity_server") {
 			isInWhitelist = true;
 		} else {
 			for (const auto& str : safeURLS) {
 				qCDebug(scriptengine) << whitelistPrefix << "Script URL: " << scriptOrURL << "TESTING AGAINST" << str << "RESULTS IN"
-						 << scriptOrURL.startsWith(str);
+					<< scriptOrURL.startsWith(str);
 				if (!str.isEmpty() && scriptOrURL.startsWith(str)) {
 					isInWhitelist = true;
 					qCDebug(scriptengine) << whitelistPrefix << "Script approved.";
-					break;  // bail early since we found a match
+					break; // bail early since we found a match
 				}
 			}
 		}

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -2377,15 +2377,21 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
         // END PULL SAFEURLS FROM INTERFACE.JSON Settings
         
         bool isInWhitelist = false;  // assume unsafe
-        for (const auto& str : safeURLS) {
-            qCDebug(scriptengine) << whitelistPrefix << "Script URL: " << scriptOrURL << "TESTING AGAINST" << str << "RESULTS IN"
-                     << scriptOrURL.startsWith(str);
-            if (!str.isEmpty() && scriptOrURL.startsWith(str)) {
-                isInWhitelist = true;
-                qCDebug(scriptengine) << whitelistPrefix << "Script approved.";
-                break;  // bail early since we found a match
-            }
-        }
+		
+		if(ScriptEngine::getContext() == "entity_server") {
+			isInWhitelist = true;
+		} else {
+			for (const auto& str : safeURLS) {
+				qCDebug(scriptengine) << whitelistPrefix << "Script URL: " << scriptOrURL << "TESTING AGAINST" << str << "RESULTS IN"
+						 << scriptOrURL.startsWith(str);
+				if (!str.isEmpty() && scriptOrURL.startsWith(str)) {
+					isInWhitelist = true;
+					qCDebug(scriptengine) << whitelistPrefix << "Script approved.";
+					break;  // bail early since we found a match
+				}
+			}
+		}
+
         if (!isInWhitelist) {
             qCDebug(scriptengine) << whitelistPrefix << "(disabled entity script)" << entityID.toString() << scriptOrURL;
             exception = makeError("UNSAFE_ENTITY_SCRIPTS == 0");


### PR DESCRIPTION
This PR does the following: 

- Disables the whitelist on the server scripts.
- File:///, cache:, and atp: are hardcoded as defaults
- You can whitelist an entire domain e.g. "hifi://thepalace"
- A setting has been added to enable or disable the whitelist, however an interface toggle has not yet been added.

To test: 

- Build a server from Athena's master, try to run entity server scripts and check the log to see if the whitelist catches them. If there is no whitelist output, it should indicate they are getting through.
- Try to load a script from the file system and from the ATP, they should both get through without hassle.
- Try to whitelist a domain with many scripts that you have not whitelisted on it, they should be accepted.
- Modify the setting for "private/whitelistEnabled" and set it to false, try to load various scripts. Then reenable it and see if they get blocked. I have not done checks on if cached scripts get through or not. This may still be an issue.