### PR TITLE
Added ArrayBuffer support to websockets

### DIFF
--- a/libraries/script-engine/src/WebSocketClass.cpp
+++ b/libraries/script-engine/src/WebSocketClass.cpp
@@ -16,6 +16,8 @@
 
 #include "ScriptEngine.h"
 
+#include "ScriptEngineLogging.h"
+
 WebSocketClass::WebSocketClass(QScriptEngine* engine, QString url) :
     _webSocket(new QWebSocket()),
     _engine(engine)
@@ -109,10 +111,10 @@ void WebSocketClass::handleOnBinaryMessage(const QByteArray& message) {
         QScriptValue arg = _engine->newObject();
         QScriptValue data = _engine->newVariant(QVariant::fromValue(message));
         QScriptValue ctor = _engine->globalObject().property("ArrayBuffer");
-        ArrayBufferClass* array = qscriptvalue_cast<ArrayBufferClass*>(ctor.data());
+        auto array = qscriptvalue_cast<ArrayBufferClass*>(ctor.data());
         QScriptValue arrayBuffer;
         if (!array) {
-            qWarning() << "WebSocketClass::handleOnBinaryMessage !ArrayBuffer";
+            qCWarning(scriptengine) << "WebSocketClass::handleOnBinaryMessage !ArrayBuffer";
         } else {
             arrayBuffer = _engine->newObject(array, data);
         }

--- a/libraries/script-engine/src/WebSocketClass.cpp
+++ b/libraries/script-engine/src/WebSocketClass.cpp
@@ -34,10 +34,11 @@ WebSocketClass::WebSocketClass(QScriptEngine* engine, QWebSocket* qWebSocket) :
 void WebSocketClass::initialize() {
     connect(_webSocket, &QWebSocket::disconnected, this, &WebSocketClass::handleOnClose);
     connect(_webSocket, &QWebSocket::textMessageReceived, this, &WebSocketClass::handleOnMessage);
+    connect(_webSocket, &QWebSocket::binaryMessageReceived, this, &WebSocketClass::handleOnBinaryMessage);
     connect(_webSocket, &QWebSocket::connected, this, &WebSocketClass::handleOnOpen);
     connect(_webSocket, static_cast<void(QWebSocket::*)(QAbstractSocket::SocketError)>(&QWebSocket::error), this,
         &WebSocketClass::handleOnError);
-    _binaryType = QStringLiteral("blob");
+    _binaryType = QStringLiteral("arraybuffer");
 }
 
 QScriptValue WebSocketClass::constructor(QScriptContext* context, QScriptEngine* engine) {
@@ -53,7 +54,12 @@ WebSocketClass::~WebSocketClass() {
 }
 
 void WebSocketClass::send(QScriptValue message) {
+    if (message.isObject()) {
+        QByteArray ba = qscriptvalue_cast<QByteArray>(message);
+        _webSocket->sendBinaryMessage(ba);
+    } else {
     _webSocket->sendTextMessage(message.toString());
+}
 }
 
 void WebSocketClass::close() {
@@ -92,6 +98,25 @@ void WebSocketClass::handleOnMessage(const QString& message) {
         QScriptValueList args;
         QScriptValue arg = _engine->newObject();
         arg.setProperty("data", message);
+        args << arg;
+        _onMessageEvent.call(QScriptValue(), args);
+    }
+}
+
+void WebSocketClass::handleOnBinaryMessage(const QByteArray& message) {
+    if (_onMessageEvent.isFunction()) {
+        QScriptValueList args;
+        QScriptValue arg = _engine->newObject();
+        QScriptValue data = _engine->newVariant(QVariant::fromValue(message));
+        QScriptValue ctor = _engine->globalObject().property("ArrayBuffer");
+        ArrayBufferClass* array = qscriptvalue_cast<ArrayBufferClass*>(ctor.data());
+        QScriptValue arrayBuffer;
+        if (!array) {
+            qWarning() << "WebSocketClass::handleOnBinaryMessage !ArrayBuffer";
+        } else {
+            arrayBuffer = _engine->newObject(array, data);
+        }
+        arg.setProperty("data", arrayBuffer);
         args << arg;
         _onMessageEvent.call(QScriptValue(), args);
     }

--- a/libraries/script-engine/src/WebSocketClass.cpp
+++ b/libraries/script-engine/src/WebSocketClass.cpp
@@ -58,8 +58,8 @@ void WebSocketClass::send(QScriptValue message) {
         QByteArray ba = qscriptvalue_cast<QByteArray>(message);
         _webSocket->sendBinaryMessage(ba);
     } else {
-    _webSocket->sendTextMessage(message.toString());
-}
+        _webSocket->sendTextMessage(message.toString());
+    }
 }
 
 void WebSocketClass::close() {

--- a/libraries/script-engine/src/WebSocketClass.h
+++ b/libraries/script-engine/src/WebSocketClass.h
@@ -123,6 +123,7 @@ private slots:
     void handleOnClose();
     void handleOnError(QAbstractSocket::SocketError error);
     void handleOnMessage(const QString& message);
+    void handleOnBinaryMessage(const QByteArray& message);
     void handleOnOpen();
 
 };


### PR DESCRIPTION
Testplan:

Run the below code in script console with PR build,
result should look like ![this](https://fluffy.ws/u/zlSsea.png)

If it looks like ![this](https://fluffy.ws/u/sVGXPy.png)
then you don't have arraybuffer support!

Code to run:
```
var ws = new WebSocket('wss://echo.websocket.org');
ws.binaryType = 'arraybuffer';
ws.onmessage = function(evt) {
    if (evt.data instanceof ArrayBuffer) {
       console.info('received binary', evt.data.byteLength, 'bytes');
       console.info('as floats', [].slice.call(new Float32Array(evt.data)));
    } else {
       console.info('received text', evt.data.length, 'chars', JSON.stringify(evt.data));
    }       
};
ws.onopen= function() { 
    console.info('connected', ws.url);
    ws.send('._.');
    ws.send(new Float32Array([0xFACE,Math.PI]).buffer)
    ws.send('._.');
};
```