### PR TITLE
Fixed clara rubbish

### DIFF
--- a/interface/resources/qml/+webengine/QmlWebWindowView.qml
+++ b/interface/resources/qml/+webengine/QmlWebWindowView.qml
@@ -40,7 +40,7 @@ Controls.WebView {
     userScripts: [ createGlobalEventBridge, raiseAndLowerKeyboard, userScript ]
 
     function onWebEventReceived(event) {
-        if (event.slice(0, 17) === "CLARA.IO DOWNLOAD") {
+        if (typeof event === 'string' && event.slice(0, 17) === "CLARA.IO DOWNLOAD") {
             ApplicationInterface.addAssetToWorldFromURL(event.slice(18));
         }
     }

--- a/interface/resources/qml/+webengine/QmlWebWindowView.qml
+++ b/interface/resources/qml/+webengine/QmlWebWindowView.qml
@@ -40,7 +40,7 @@ Controls.WebView {
     userScripts: [ createGlobalEventBridge, raiseAndLowerKeyboard, userScript ]
 
     function onWebEventReceived(event) {
-        if (typeof event === 'string' && event.slice(0, 17) === "CLARA.IO DOWNLOAD") {
+        if (typeof event === "string" && event.slice(0, 17) === "CLARA.IO DOWNLOAD") {
             ApplicationInterface.addAssetToWorldFromURL(event.slice(18));
         }
     }

--- a/interface/resources/qml/hifi/tablet/TabletRoot.qml
+++ b/interface/resources/qml/hifi/tablet/TabletRoot.qml
@@ -200,7 +200,7 @@ Rectangle {
         id: eventBridgeConnection
         target: eventBridge
         onWebEventReceived: {
-            if (typeof message === 'string' && message.slice(0, 17) === "CLARA.IO DOWNLOAD") {
+            if (typeof message === "string" && message.slice(0, 17) === "CLARA.IO DOWNLOAD") {
                 ApplicationInterface.addAssetToWorldFromURL(message.slice(18));
             }
         }

--- a/interface/resources/qml/hifi/tablet/TabletRoot.qml
+++ b/interface/resources/qml/hifi/tablet/TabletRoot.qml
@@ -200,7 +200,7 @@ Rectangle {
         id: eventBridgeConnection
         target: eventBridge
         onWebEventReceived: {
-            if (message.slice(0, 17) === "CLARA.IO DOWNLOAD") {
+            if (typeof message === 'string' && message.slice(0, 17) === "CLARA.IO DOWNLOAD") {
                 ApplicationInterface.addAssetToWorldFromURL(message.slice(18));
             }
         }

--- a/interface/resources/qml/hifi/tablet/WindowRoot.qml
+++ b/interface/resources/qml/hifi/tablet/WindowRoot.qml
@@ -118,7 +118,7 @@ Windows.ScrollingWindow {
         id: eventBridgeConnection
         target: eventBridge
         onWebEventReceived: {
-            if (typeof message === 'string' && message.slice(0, 17) === "CLARA.IO DOWNLOAD") {
+            if (typeof message === "string" && message.slice(0, 17) === "CLARA.IO DOWNLOAD") {
                 ApplicationInterface.addAssetToWorldFromURL(message.slice(18));
             }
         }

--- a/interface/resources/qml/hifi/tablet/WindowRoot.qml
+++ b/interface/resources/qml/hifi/tablet/WindowRoot.qml
@@ -118,7 +118,7 @@ Windows.ScrollingWindow {
         id: eventBridgeConnection
         target: eventBridge
         onWebEventReceived: {
-            if (message.slice(0, 17) === "CLARA.IO DOWNLOAD") {
+            if (typeof message === 'string' && message.slice(0, 17) === "CLARA.IO DOWNLOAD") {
                 ApplicationInterface.addAssetToWorldFromURL(message.slice(18));
             }
         }


### PR DESCRIPTION
This PR stops Interface from throwing errors in the log because objects are sent over the EventBridge instead of strings.

Testplan:

Enable verbose mode by Developer>Scripting>Verbose Logging

Run the below code in script console with PR build,
If you see 
`[WARNING] [default] qrc:/qml/+webengine/QmlWebWindowView.qml:43: TypeError: Type error`
or
`[WARNING] [default] qrc:/qml/+webengine/QmlWebWindowView.qml:43: TypeError: Property 'slice' of object [object Object] is not a function`

then it did not work.

Code to run:
```
window = new OverlayWebWindow({ x: 5, y: 5, width: 640, height: 480 });
window.setURL("data:text/html;text,<html>[<script>setTimeout(function() { EventBridge.emitWebEvent({ type: 'buffer', data: [1,2,3,4,5,6] }) }, 1000);</script>]</html>//.html");
window.webEventReceived.connect(function(msg) { console.info('message from web view', msg.type, msg.data); })
```

Test for string data:
```
window = new OverlayWebWindow({ x: 5, y: 5, width: 640, height: 480 });
window.setURL("data:text/html;text,<html>[<script>setTimeout(function() { EventBridge.emitWebEvent('._.');}, 1000);</script>]</html>//.html");
window.webEventReceived.connect(function(msg) { console.info('message from web view', msg); })
```