### PR TITLE
Added /l /d /g chatbar switches and /goto and /me

### DIFF
--- a/scripts/communityModules/chat/FloofChat.html
+++ b/scripts/communityModules/chat/FloofChat.html
@@ -194,7 +194,7 @@
                 var part1 = text.substring(0, firstMatch - 2);
                 var part2 = text.substring(firstMatch, secondMatch);
                 var part3 = text.substring(secondMatch + 2);
-                text = part1 + "<i>" + part2 + "</i>" + part3;
+                text = part1 + "<b>" + part2 + "</b>" + part3;
             }
         } else if (text.indexOf("*") !== -1) {
             var firstMatch = text.indexOf("*") + 1;
@@ -204,7 +204,7 @@
                 var part1 = text.substring(0, firstMatch - 1);
                 var part2 = text.substring(firstMatch, secondMatch);
                 var part3 = text.substring(secondMatch + 1);
-                text = part1 + "<b>" + part2 + "</b>" + part3;
+                text = part1 + "<i>" + part2 + "</i>" + part3;
             }
         } else if (text.indexOf("__") !== -1) {
             var firstMatch = text.indexOf("__") + 2;

--- a/scripts/communityModules/chat/FloofChat.js
+++ b/scripts/communityModules/chat/FloofChat.js
@@ -174,7 +174,7 @@ var chatBarChannel = "Local";
 
 
 function gotoConfirm(url) {
-    var result = Window.confirm("Do you want to goto " + ((url.indexOf("/") !== -1) ? url.split("/")[2] : url) + " ?");
+    var result = Window.confirm("Do you want to go to '" + ((url.indexOf("/") !== -1) ? url.split("/")[2] : url) + "'?");
     if (result) {
         location = url;
     }


### PR DESCRIPTION
Testing is just,

on the chatbar on the bottom of the screen, you can do
/l to switch to local (default)
/d for domain
/g for grid
verify the above work.

/me is for firstperson talking so "/me sits" equates to "Fluffy sits"

"/goto thepalace" a window should popup asking if you want to go there (the same as when you click on a hifi:// url in the chat window)

if the placename/ip/url doesn't exist then it will silently fail as does all other gotos

Meow