### PR TITLE
Quick fix for the metaverse API

### DIFF
--- a/libraries/networking/src/NetworkingConstants.h
+++ b/libraries/networking/src/NetworkingConstants.h
@@ -25,7 +25,7 @@ namespace NetworkingConstants {
     // if you manually generate a personal access token for the domains scope
     // at https://staging.highfidelity.com/user/tokens/new?for_domain_server=true
 
-    const QUrl METAVERSE_SERVER_URL_STABLE { "https://metaverse.projectathena.io" };
+    const QUrl METAVERSE_SERVER_URL_STABLE { "https://metaverse.highfidelity.com" };
     const QUrl METAVERSE_SERVER_URL_STAGING { "https://staging.projectathena.io" };
 }
 

--- a/tools/nitpick/AppDataHighFidelity/Interface.json
+++ b/tools/nitpick/AppDataHighFidelity/Interface.json
@@ -279,5 +279,6 @@
     "toolbar/com.highfidelity.interface.toolbar.system/x": 655,
     "toolbar/com.highfidelity.interface.toolbar.system/y": 953,
     "toolbar/constrainToolbarToCenterX": true,
+    "private/selectedMetaverseURL": "https://metaverse.highfidelity.com",
     "wallet/autoLogout": true
 }


### PR DESCRIPTION
We did have the dfault metaverse API as metaverse.projectathena.io, but that doesn't not yet exist, and it turns out we can't just do a redirect. So for now changing it to metaverse.highfidelity.com