### PR TITLE
Make default copy constructors explicit

### DIFF
--- a/interface/src/raypick/StylusPick.h
+++ b/interface/src/raypick/StylusPick.h
@@ -31,6 +31,8 @@ public:
         surfaceNormal = stylusPickResult.surfaceNormal;
     }
 
+    StylusPickResult& operator=(const StylusPickResult &right) = default;
+
     IntersectionType type { NONE };
     bool intersects { false };
     QUuid objectID;

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -162,6 +162,7 @@ protected:
                     const QString& typeVarIn, const QString& weightVarIn, float weightIn, const std::vector<float>& flexCoefficientsIn,
                     const QString& poleVectorEnabledVar, const QString& poleReferenceVectorVar, const QString& poleVectorVar);
         IKTargetVar(const IKTargetVar& orig);
+        AnimInverseKinematics::IKTargetVar& operator=(const AnimInverseKinematics::IKTargetVar&) = default;
 
         QString jointName;
         QString positionVar;

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -121,6 +121,8 @@ public:
     static void propertiesToBlob(QScriptEngine& scriptEngine, const QUuid& myAvatarID, const EntityItemProperties& properties, QByteArray& blob);
 
     EntityItemProperties(EntityPropertyFlags desiredProperties = EntityPropertyFlags());
+    EntityItemProperties(const EntityItemProperties&) = default;
+
     virtual ~EntityItemProperties() = default;
 
     void merge(const EntityItemProperties& other);

--- a/libraries/entities/src/SimulationOwner.h
+++ b/libraries/entities/src/SimulationOwner.h
@@ -112,6 +112,7 @@ public:
 
     SimulationOwner();
     SimulationOwner(const QUuid& id, uint8_t priority);
+    SimulationOwner(const SimulationOwner &) = default;
 
     const QUuid& getID() const { return _id; }
     const uint64_t& getExpiry() const { return _expiry; }

--- a/libraries/image/src/image/Image.h
+++ b/libraries/image/src/image/Image.h
@@ -59,7 +59,7 @@ namespace image {
         Image() : _dims(0,0) {}
         Image(int width, int height, Format format);
         Image(const QImage& data) : _packedData(data), _dims(data.width(), data.height()), _format((Format)data.format()) {}
-
+        Image(const Image &other) = default;
         void operator=(const QImage& other) {
             _packedData = other;
             _floatData.clear();

--- a/libraries/shared/src/CubicHermiteSpline.h
+++ b/libraries/shared/src/CubicHermiteSpline.h
@@ -19,6 +19,8 @@ public:
 
     CubicHermiteSplineFunctor(const CubicHermiteSplineFunctor& orig) : _p0(orig._p0), _m0(orig._m0), _p1(orig._p1), _m1(orig._m1) {}
 
+    CubicHermiteSplineFunctor& operator=(const CubicHermiteSplineFunctor&) = default;
+
     virtual ~CubicHermiteSplineFunctor() {}
 
     // evalute the hermite curve at parameter t (0..1)
@@ -84,6 +86,8 @@ public:
     CubicHermiteSplineFunctorWithArcLength(const CubicHermiteSplineFunctorWithArcLength& orig) : CubicHermiteSplineFunctor(orig) {
         memcpy(_values, orig._values, sizeof(float) * (NUM_SUBDIVISIONS + 1));
     }
+
+    CubicHermiteSplineFunctorWithArcLength& operator=(const CubicHermiteSplineFunctorWithArcLength&) = default;
 
     // given the spline parameter (0..1) output the arcLength of the spline up to that point.
     float arcLength(float t) const {

--- a/libraries/shared/src/shared/MediaTypeLibrary.h
+++ b/libraries/shared/src/shared/MediaTypeLibrary.h
@@ -48,6 +48,7 @@ public:
         webMediaTypes(mediaType.webMediaTypes),
         fileSignatures(mediaType.fileSignatures) {
     }
+    MediaType& operator=(const MediaType&) = default;
 
     static MediaType NONE;
 


### PR DESCRIPTION
Recent versions of gcc generate a warning without this. This follows the deprecation of this in the C++11 standard. The result is a huge amount of warnings in the Linux build.

This change should be pretty much a no-op, because everything was declared as "= default", meaning the compiler will keep doing exactly what it was doing before just without a warning.

The reasoning for this change is the rule of three: https://en.cppreference.com/w/cpp/language/rule_of_three

> If a class requires a user-defined destructor, a user-defined copy constructor, or a user-defined copy assignment operator, it almost certainly requires all three.

So, I reviewed those classes, and so far my conclusion that a default copy constructions and operator= should work correctly, but I definitely would welcome second opinions here.

This shouldn't make anything worse or different in any way. The worst possible outcome should be to give the okay to an existing bug.

