### PR TITLE
Update BUILD_LINUX.md

### DIFF
--- a/BUILD_LINUX.md
+++ b/BUILD_LINUX.md
@@ -115,8 +115,8 @@ make interface
 
 The commands above will compile with a single thread. If you have enough memory,
 you can decrease your build time using the `-j` flag. Since most x64 CPUs
-support two threads per core, this works out to CPU_COUNT*2. If you have a 2
-core machine, you could use:
+support two threads per core, this works out to CPU_COUNT*2. As an example, if
+you have a 2 core machine, you could use:
 ```
 make -j4 interface
 ```
@@ -151,7 +151,8 @@ Go to localhost in the running interface.
 #### Notes
 
 If your goal is to set up a development environment, it is desirable to set the
-directory that vcpkg builds to via the `HIFI_VCPKG_BASE` environment variable.
+directory that vcpkg builds into with the `HIFI_VCPKG_BASE` environment variable.
+For example, you might set `HIFI_VCPKG_BASE` to `/home/$USER/vcpkg`.
 By default, vcpkg will build in the system `/tmp` directory.
 
 ##### Ubuntu 18.04 only

--- a/BUILD_LINUX.md
+++ b/BUILD_LINUX.md
@@ -40,12 +40,12 @@ wget https://cmake.org/files/v3.14/cmake-3.14.2-Linux-x86_64.sh
 sudo sh cmake-3.14.2-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 ```
 #### Install build dependencies:
--  OpenSSL  
+-  OpenSSL:
 ```bash
 sudo apt-get install libssl-dev
 ```
 Verify with `openssl version`  
-- OpenGL
+- OpenGL:
 ```bash
 sudo apt-get install libgl1-mesa-dev -y
 sudo ln -s /usr/lib/x86_64-linux-gnu/libGL.so.346.35 /usr/lib/x86_64-linux-gnu/libGL.so.1.2.0
@@ -57,32 +57,32 @@ sudo ln -s /usr/lib/x86_64-linux-gnu/libGL.so.346.35 /usr/lib/x86_64-linux-gnu/l
 ```bash
 sudo apt-get -y install libpulse0 libnss3 libnspr4 libfontconfig1 libxcursor1 libxcomposite1 libxtst6 libxslt1.1
 ```
--  Misc dependencies
+-  Misc dependencies:
 ```bash
 sudo apt-get install libasound2 libxmu-dev libxi-dev freeglut3-dev libasound2-dev libjack0 libjack-dev libxrandr-dev libudev-dev libssl-dev zlib1g-dev
 ```
--  Install Python 3 and required packages
+-  Install Python 3 and required packages:
 ```bash
 sudo apt-get install python python3 python3-distro
 ```
--  Install node, required to build the jsdoc documentation
+-  Install node, required to build the jsdoc documentation:
 ```bash
 sudo apt-get install nodejs
 ```
 
-### Get code and checkout the tag you need
+### Get code and checkout the branch you need
 
 Clone this repository:
 ```bash
 git clone https://github.com/kasenvr/project-athena.git
 ```
 
-To compile a RELEASE version checkout the tag you need getting a list of all tags:
+To compile a DEV version checkout the branch you need. To get a list of all tags:
 ```bash
 git fetch -a
 ```
 
-Then checkout last tag with:
+Then checkout the main branch with:
 ```bash
 git checkout kasen/core
 ```
@@ -121,7 +121,7 @@ core machine, you could use:
 make -j4 interface
 ```
 
-In a server, it does not make sense to compile interface
+In a server, it does not make sense to compile interface.
 
 ### Running the software
 
@@ -150,7 +150,7 @@ Go to localhost in the running interface.
 
 #### Notes
 
-If your goal is to setup a development environment, it is desirable to set the
+If your goal is to setup a development environment, it is desirable to set up the
 directory that vcpkg builds to via the `HIFI_VCPKG_BASE` environment variable.
 By default, vcpkg will build in the system `/tmp` directory.
 

--- a/BUILD_LINUX.md
+++ b/BUILD_LINUX.md
@@ -14,60 +14,58 @@ sudo add-apt-repository universe
 sudo apt-get update
 ```
 #### Install build tools:
-1.  First update the repositiories:  
+-  First update the repositiories:  
 ```bash
 sudo apt-get update -y
 sudo apt-get upgrade -y
 ```
-1.  git
+-  git
 ```bash
 sudo apt-get install git -y
 ```
 Verify by git --version  
-1.  g++
+-  g++
 ```bash
 sudo apt-get install g++ -y
 ```
 Verify by g++ --version  
-1.  *Ubuntu 18.04* cmake
+-  *Ubuntu 18.04* cmake
 ```bash
 sudo apt-get install cmake -y
 ```
 Verify by cmake --version  
-1. *Ubuntu 16.04* cmake  
+- *Ubuntu 16.04* cmake  
 ```bash
 wget https://cmake.org/files/v3.14/cmake-3.14.2-Linux-x86_64.sh
 sudo sh cmake-3.14.2-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 ```
 #### Install build dependencies:
-1.  OpenSSL  
+-  OpenSSL  
 ```bash
 sudo apt-get install libssl-dev
 ```
 Verify with `openssl version`  
-1.  OpenGL  
-Verify (first install mesa-utils - `sudo apt install mesa-utils -y`) by `glxinfo | grep "OpenGL version"`  
+- OpenGL
 ```bash
 sudo apt-get install libgl1-mesa-dev -y
 sudo ln -s /usr/lib/x86_64-linux-gnu/libGL.so.346.35 /usr/lib/x86_64-linux-gnu/libGL.so.1.2.0
 ```
+- Verify OpenGL:
+  - First install mesa-utils with the command `sudo apt install mesa-utils -y`
+  - Then run `glxinfo | grep "OpenGL version"`  
 #### To compile interface in a server you must install:
 ```bash
 sudo apt-get -y install libpulse0 libnss3 libnspr4 libfontconfig1 libxcursor1 libxcomposite1 libxtst6 libxslt1.1
 ```
-1.  Misc dependencies
+-  Misc dependencies
 ```bash
 sudo apt-get install libasound2 libxmu-dev libxi-dev freeglut3-dev libasound2-dev libjack0 libjack-dev libxrandr-dev libudev-dev libssl-dev zlib1g-dev
 ```
-1.  To compile interface in a server you must install:
+-  Install Python 3 and required packages
 ```bash
-sudo apt-get -y install libpulse0 libnss3 libnspr4 libfontconfig1 libxcursor1 libxcomposite1 libxtst6 libxslt1.1
+sudo apt-get install python python3 python3-distro
 ```
-1.  Install Python 3 and required packages
-```bash
-sudo apt-get install python3 python3-distro
-```
-1.  Install node, required to build the jsdoc documentation
+-  Install node, required to build the jsdoc documentation
 ```bash
 sudo apt-get install nodejs
 ```
@@ -82,12 +80,11 @@ git clone https://github.com/kasenvr/project-athena.git
 To compile a RELEASE version checkout the tag you need getting a list of all tags:
 ```bash
 git fetch -a
-git tag
 ```
 
 Then checkout last tag with:
 ```bash
-git checkout tag/1.0
+git checkout kasen/core
 ```
 
 ### Compiling
@@ -104,7 +101,7 @@ Prepare makefiles:
 cmake ..
 ```
 
-*  If cmake fails with a vcpkg error - delete /tmp/hifi/vcpkg.  
+- If cmake fails with a vcpkg error - delete /tmp/hifi/vcpkg.  
 
 Start compilation of the server and get a cup of coffee:
 ```bash
@@ -114,6 +111,14 @@ make domain-server assignment-client
 To compile interface:
 ```bash
 make interface
+```
+
+The commands above will compile with a single thread. If you have enough memory,
+you can decrease your build time using the `-j` flag. Since most x64 CPUs
+support two threads per core, this works out to CPU_COUNT*2. If you have a 2
+core machine, you could use:
+```
+make -j4 interface
 ```
 
 In a server, it does not make sense to compile interface
@@ -142,6 +147,12 @@ Running interface:
 ```
 
 Go to localhost in the running interface.
+
+#### Notes
+
+If your goal is to setup a development environment, it is desirable to set the
+directory that vcpkg builds to via the `HIFI_VCPKG_BASE` environment variable.
+By default, vcpkg will build in the system `/tmp` directory.
 
 ##### Ubuntu 18.04 only
 

--- a/BUILD_LINUX.md
+++ b/BUILD_LINUX.md
@@ -150,7 +150,7 @@ Go to localhost in the running interface.
 
 #### Notes
 
-If your goal is to setup a development environment, it is desirable to set up the
+If your goal is to set up a development environment, it is desirable to set the
 directory that vcpkg builds to via the `HIFI_VCPKG_BASE` environment variable.
 By default, vcpkg will build in the system `/tmp` directory.
 


### PR DESCRIPTION
- Fix python installation instructions.
- Remove redundant instructions.
- Since we are not using tags, instruct users to checkout `kasen/core`.
- Add instructions for a faster compile.
- Add optional instruction for the `HIFI_VCPKG_BASE` environment variable.
- Style fixes.