### PR TITLE
Update API Docs for readability

### DIFF
--- a/tools/jsdoc/hifi-jsdoc-template/static/styles/night.css
+++ b/tools/jsdoc/hifi-jsdoc-template/static/styles/night.css
@@ -14,11 +14,6 @@ section {
 	background-color: #061F2F;
 }
 
-code {
-	background-color: #0a121b !important;
-	padding: 3px;
-}
-
 /* Prettify */
 
 .typ {
@@ -45,6 +40,14 @@ code {
 	color: #9d9d9d !important;
 }
 
+.prettyprint code {
+	background-color: #0a121b;
+}
+
+tr td a code {
+	font-weight: bold;
+}
+
 /* JSDoc */
 
 thead {
@@ -61,6 +64,11 @@ table tr:nth-child(2n) {
 
 .name code {
 	color: #e8a0e8 !important;
+	font-weight: bold;
+}
+
+.signature {
+	font-weight: bold;
 }
 
 #main a, #main a:visited, #main a:active, #main a:hover {

--- a/tools/jsdoc/hifi-jsdoc-template/static/styles/night.css
+++ b/tools/jsdoc/hifi-jsdoc-template/static/styles/night.css
@@ -16,6 +16,7 @@ section {
 
 code {
 	background-color: #0a121b !important;
+	padding: 3px;
 }
 
 /* Prettify */
@@ -38,6 +39,10 @@ code {
 
 .str {
 	color: #f08d49 !important;
+}
+
+.com {
+	color: #9d9d9d !important;
 }
 
 /* JSDoc */


### PR DESCRIPTION
Nightmode: Code no longer has a BG unless it is in a block, all other main non-block code tags are bolded for visibility. Comments in codeblocks are now a bit brighter.

![image](https://user-images.githubusercontent.com/52365539/73083072-86753200-3e98-11ea-9790-c406a3ff0f5d.png)
