### PR TITLE
Added basic beta default scripts feature

### DIFF
--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -54,7 +54,8 @@ var MENU_ITEM = "Debug defaultScripts.js";
 
 var SETTINGS_KEY = '_debugDefaultScriptsIsChecked';
 var SETTINGS_KEY_BETA = '_betaDefaultScriptsIsChecked';
-var previousSetting = Settings.getValue(SETTINGS_KEY, false);
+var previousSetting = Settings.getValue(SETTINGS_KEY, false);;
+var previousSettingBeta = Settings.getValue(SETTINGS_KEY_BETA, false);
 
 if (previousSetting === '' || previousSetting === false || previousSetting === 'false') {
     previousSetting = false;
@@ -91,7 +92,7 @@ function loadSeparateDefaults() {
             var currentRunningScriptObject = currentlyRunningScripts[j];
             var currentDefaultScriptName = scriptItem.substr((scriptItem.lastIndexOf("/") + 1), scriptItem.length);
             if (currentDefaultScriptName === currentRunningScriptObject.name) {
-                shouldLoadCurrentDefaultScript = false;
+                ScriptDiscoveryService.stopScript(currentRunningScriptObject.url);
             }
         }
 

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -54,7 +54,7 @@ var MENU_ITEM = "Debug defaultScripts.js";
 
 var SETTINGS_KEY = '_debugDefaultScriptsIsChecked';
 var SETTINGS_KEY_BETA = '_betaDefaultScriptsIsChecked';
-var previousSetting = Settings.getValue(SETTINGS_KEY, false);;
+var previousSetting = Settings.getValue(SETTINGS_KEY, false);
 var previousSettingBeta = Settings.getValue(SETTINGS_KEY_BETA, false);
 
 if (previousSetting === '' || previousSetting === false || previousSetting === 'false') {
@@ -73,6 +73,7 @@ if (Menu.menuExists(MENU_CATEGORY) && !Menu.menuItemExists(MENU_CATEGORY, MENU_I
         isChecked: previousSetting,
     });
 }
+
 function loadSeparateDefaults() {
     var currentlyRunningScripts = ScriptDiscoveryService.getRunning();
 
@@ -81,7 +82,7 @@ function loadSeparateDefaults() {
         var scriptItem = DEFAULT_SCRIPTS_SEPARATE[i];
         if (typeof scriptItem === "object") {
             if (previousSettingBeta) {
-                console.info("Loading Beta item " + scriptItem.beta);
+                console.log("Loading Beta item " + scriptItem.beta);
                 scriptItem = scriptItem.beta;
             } else {
                 scriptItem = scriptItem.stable;
@@ -92,7 +93,11 @@ function loadSeparateDefaults() {
             var currentRunningScriptObject = currentlyRunningScripts[j];
             var currentDefaultScriptName = scriptItem.substr((scriptItem.lastIndexOf("/") + 1), scriptItem.length);
             if (currentDefaultScriptName === currentRunningScriptObject.name) {
-                ScriptDiscoveryService.stopScript(currentRunningScriptObject.url);
+                if (currentRunningScriptObject.url !== scriptItem) {
+                    ScriptDiscoveryService.stopScript(currentRunningScriptObject.url);
+                } else {
+                    shouldLoadCurrentDefaultScript = false;
+                }
             }
         }
 

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -39,7 +39,7 @@ var DEFAULT_SCRIPTS_COMBINED = [
 var DEFAULT_SCRIPTS_SEPARATE = [
     "system/controllers/controllerScripts.js",
     "communityModules/notificationCore/notificationCore.js",
-    "communityModules/chat/FloofChat.js"
+    {"stable": "communityModules/chat/FloofChat.js", "beta": "https://content.fluffy.ws/scripts/chat/FloofChat.js"}
     //"system/chat.js"
 ];
 
@@ -53,7 +53,8 @@ var MENU_CATEGORY = "Developer > Scripting";
 var MENU_ITEM = "Debug defaultScripts.js";
 
 var SETTINGS_KEY = '_debugDefaultScriptsIsChecked';
-var previousSetting = Settings.getValue(SETTINGS_KEY);
+var SETTINGS_KEY_BETA = '_betaDefaultScriptsIsChecked';
+var previousSetting = Settings.getValue(SETTINGS_KEY, false);
 
 if (previousSetting === '' || previousSetting === false || previousSetting === 'false') {
     previousSetting = false;
@@ -71,23 +72,31 @@ if (Menu.menuExists(MENU_CATEGORY) && !Menu.menuItemExists(MENU_CATEGORY, MENU_I
         isChecked: previousSetting,
     });
 }
-
 function loadSeparateDefaults() {
     var currentlyRunningScripts = ScriptDiscoveryService.getRunning();
 
     for (var i in DEFAULT_SCRIPTS_SEPARATE) {
         var shouldLoadCurrentDefaultScript = true;
+        var scriptItem = DEFAULT_SCRIPTS_SEPARATE[i];
+        if (typeof scriptItem === "object") {
+            if (previousSettingBeta) {
+                console.info("Loading Beta item " + scriptItem.beta);
+                scriptItem = scriptItem.beta;
+            } else {
+                scriptItem = scriptItem.stable;
+            }
+        }
 
         for (var j = 0; j < currentlyRunningScripts.length; j++) {
             var currentRunningScriptObject = currentlyRunningScripts[j];
-            var currentDefaultScriptName = DEFAULT_SCRIPTS_SEPARATE[i].substr((DEFAULT_SCRIPTS_SEPARATE[i].lastIndexOf("/") + 1), DEFAULT_SCRIPTS_SEPARATE[i].length);
+            var currentDefaultScriptName = scriptItem.substr((scriptItem.lastIndexOf("/") + 1), scriptItem.length);
             if (currentDefaultScriptName === currentRunningScriptObject.name) {
                 shouldLoadCurrentDefaultScript = false;
             }
         }
 
         if (shouldLoadCurrentDefaultScript) {
-            Script.load(DEFAULT_SCRIPTS_SEPARATE[i]);
+            Script.load(scriptItem);
         }
     }
 }
@@ -161,7 +170,7 @@ function removeMenuItem() {
     }
 }
 
-Script.scriptEnding.connect(function() {
+Script.scriptEnding.connect(function () {
     removeMenuItem();
 });
 


### PR DESCRIPTION
To enable run 
`Settings.setValue("_betaDefaultScriptsIsChecked", true);`
in your script console and then restart your default scripts or restart interface

(You may have to stop the FloofChat.js script first before it will switch to the beta version)