### PR TITLE
Force dynamic build on Linux

### DIFF
--- a/cmake/init.cmake
+++ b/cmake/init.cmake
@@ -62,3 +62,11 @@ endif ()
 if (APPLE)
   set(CMAKE_XCODE_ATTRIBUTE_OTHER_CODE_SIGN_FLAGS "--deep")
 endif()
+
+if (UNIX)
+  # Static libs result in duplicated constructor and destructor calls on Linux
+  # and crashes on exit, and perhaps loss of global state on plugin loads.
+  #
+  # This will need to be looked at closely before Linux can have a static build.
+  set(BUILD_SHARED_LIBS ON)
+endif ()

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -142,6 +142,9 @@ if (APPLE)
   list(APPEND INTERFACE_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/icon/${INTERFACE_ICON_FILENAME})
 endif()
 
+if (UNIX)
+  set(BUILD_SHARED_LIBS ON)
+endif ()
 
 # create the executable, make it a bundle on OS X
 if (APPLE)


### PR DESCRIPTION
Fixes crashes on shutdown on Linux, see  #151 

Static libraries result in misbehavior on Linux. Here's my understanding of what happens:

1. You do a `static Foo foo;` in shared.
2. Logically, this creates a call to the `Foo` constructor.
3. Shared gets statically linked into both libfoo and libbar. Of course each of those now has the constructor call. They're static, so each has to include that code.
4. Both libfoo and libbar get statically linked into libplugin, which now gets two copies of the same code, and stuff gets  called twice.

This results in crashes on shutdown as destructors get called more than once, and this results in a double-free. This is sort of harmless, but there are possible grave issues:

1. Constructors also are called multiple times. This will overwrite the global data on events like a plugin load, leading to a loss of state. This can mean weird, hard to trace down bugs.
2. A bad shutdown can result in data loss from things not being given the chance to terminate correctly.
3. It will lead to a report of a crash to the user, which leaves a bad impression
4. It anything that relies on correct termination (like scripts or some debugging tools) malfunction.

Possible solutions were considered:

1. Change the code to avoid the crash. This was attempted, but seems to be a fair amount of work for little benefit. After fixing the initial crash a new, similar one appeared.
2. Ignore the problem and call `exit_`. This means a bad shutdown with possible data loss. Shutdown handlers exist for a reason.
3. Link dynamically. This works and is very easy to do.


