### PR TITLE
Add support for serverless domains via HTTP/HTTPS

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5517,6 +5517,8 @@ bool Application::importEntities(const QString& urlOrFilename, const bool isObse
     _entityClipboard->withWriteLock([&] {
         _entityClipboard->eraseAllOctreeElements();
 
+        // FIXME: readFromURL() can take over the main event loop which may cause problems, especially if downloading the JSON 
+        // from the Web.
         success = _entityClipboard->readFromURL(urlOrFilename, isObservable, callerId);
         if (success) {
             _entityClipboard->reaverageOctreeElements();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -9263,7 +9263,7 @@ void Application::readArgumentsFromLocalSocket() const {
 
     // If we received a message, try to open it as a URL
     if (message.length() > 0) {
-        DependencyManager::get<WindowScriptingInterface>()->openUrl(QString::fromUtf8(message));
+        DependencyManager::get<AddressManager>()->handleLookupString(QString::fromUtf8(message));
     }
 }
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -464,7 +464,7 @@ public slots:
     void setPreferredCursor(const QString& cursor);
 
     void setIsServerlessMode(bool serverlessDomain);
-    std::map<QString, QString> prepareServerlessDomainContents(QUrl domainURL);
+    std::map<QString, QString> prepareServerlessDomainContents(QUrl domainURL, QByteArray data);
 
     void loadServerlessDomain(QUrl domainURL);
     void loadErrorDomain(QUrl domainURL);

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -262,7 +262,9 @@ int main(int argc, const char* argv[]) {
         if (socket.waitForConnected(LOCAL_SERVER_TIMEOUT_MS)) {
             if (parser.isSet(urlOption)) {
                 QUrl url = QUrl(parser.value(urlOption));
-                if (url.isValid() && (url.scheme() == URL_SCHEME_HIFI || url.scheme() == URL_SCHEME_HIFIAPP)) {
+                if (url.isValid() && (url.scheme() == URL_SCHEME_HIFI || url.scheme() == URL_SCHEME_HIFIAPP
+                        || url.scheme() == HIFI_URL_SCHEME_HTTP || url.scheme() == HIFI_URL_SCHEME_HTTPS
+                        || url.scheme() == HIFI_URL_SCHEME_FILE)) {
                     qDebug() << "Writing URL to local socket";
                     socket.write(url.toString().toUtf8());
                     if (!socket.waitForBytesWritten(5000)) {

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -157,6 +157,7 @@ void AddressManager::storeCurrentAddress() {
     auto url = currentAddress();
 
     if (url.scheme() == HIFI_URL_SCHEME_FILE ||
+        url.scheme() == HIFI_URL_SCHEME_HTTP || url.scheme() == HIFI_URL_SCHEME_HTTPS ||
         (url.scheme() == URL_SCHEME_HIFI && !url.host().isEmpty())) {
         // TODO -- once Octree::readFromURL no-longer takes over the main event-loop, serverless-domain urls can
         // be loaded over http(s)

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -361,8 +361,9 @@ bool AddressManager::handleUrl(const QUrl& lookupUrlIn, LookupTrigger trigger) {
         return true;
     } else if (lookupUrl.scheme() == HIFI_URL_SCHEME_FILE || lookupUrl.scheme() == HIFI_URL_SCHEME_HTTPS
             || lookupUrl.scheme() == HIFI_URL_SCHEME_HTTP) {
-        // TODO once a file can return a connection refusal if there were to be some kind of load error, we'd
-        // need to store the previous domain tried in _lastVisitedURL. For now , do not store it.
+               
+        // Save the last visited domain URL.
+        _lastVisitedURL = lookupUrl;
 
         _previousAPILookup.clear();
         _shareablePlaceName.clear();

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -358,11 +358,8 @@ bool AddressManager::handleUrl(const QUrl& lookupUrlIn, LookupTrigger trigger) {
         emit lookupResultsFinished();
 
         return true;
-    } else if (lookupUrl.scheme() == HIFI_URL_SCHEME_FILE) {
-        // TODO -- once Octree::readFromURL no-longer takes over the main event-loop, serverless-domain urls can
-        // be loaded over http(s)
-        // lookupUrl.scheme() == URL_SCHEME_HTTP ||
-        // lookupUrl.scheme() == HIFI_URL_SCHEME_HTTPS ||
+    } else if (lookupUrl.scheme() == HIFI_URL_SCHEME_FILE || lookupUrl.scheme() == HIFI_URL_SCHEME_HTTPS
+            || lookupUrl.scheme() == HIFI_URL_SCHEME_HTTP) {
         // TODO once a file can return a connection refusal if there were to be some kind of load error, we'd
         // need to store the previous domain tried in _lastVisitedURL. For now , do not store it.
 

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -209,7 +209,9 @@ void DomainHandler::setURLAndID(QUrl domainURL, QUuid domainID) {
     }
 
     // if it's in the error state, reset and try again.
-    if ((_domainURL != domainURL || _sockAddr.getPort() != domainPort) || _isInErrorState) {
+    if (_domainURL != domainURL 
+        || (_sockAddr.getPort() != domainPort && domainURL.scheme() == URL_SCHEME_HIFI)
+        || _isInErrorState) {
         // re-set the domain info so that auth information is reloaded
         hardReset("Changing domain URL");
 

--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -738,7 +738,6 @@ bool Octree::readFromURL(
 ) {
     QString trimmedUrl = urlString.trimmed();
     QString marketplaceID = getMarketplaceID(trimmedUrl);
-    qDebug() << "!!!!! going to createResourceRequest " << callerId;
     auto request = std::unique_ptr<ResourceRequest>(
         DependencyManager::get<ResourceManager>()->createResourceRequest(
             this, trimmedUrl, isObservable, callerId, "Octree::readFromURL"));
@@ -770,6 +769,24 @@ bool Octree::readFromURL(
     return readFromStream(data.size(), inputStream, marketplaceID);
 }
 
+bool Octree::readFromByteArray(
+    const QString& urlString,
+    const QByteArray& data
+) {
+    QString trimmedUrl = urlString.trimmed();
+    QString marketplaceID = getMarketplaceID(trimmedUrl);
+
+    QByteArray uncompressedJsonData;
+    bool wasCompressed = gunzip(data, uncompressedJsonData);
+
+    if (wasCompressed) {
+        QDataStream inputStream(uncompressedJsonData);
+        return readFromStream(uncompressedJsonData.size(), inputStream, marketplaceID);
+    }
+
+    QDataStream inputStream(data);
+    return readFromStream(data.size(), inputStream, marketplaceID);
+}
 
 bool Octree::readFromStream(
     uint64_t streamLength,

--- a/libraries/octree/src/Octree.h
+++ b/libraries/octree/src/Octree.h
@@ -217,6 +217,7 @@ public:
     // Octree importers
     bool readFromFile(const char* filename);
     bool readFromURL(const QString& url, const bool isObservable = true, const qint64 callerId = -1); // will support file urls as well...
+    bool readFromByteArray(const QString& url, const QByteArray& byteArray);
     bool readFromStream(uint64_t streamLength, QDataStream& inputStream, const QString& marketplaceID="");
     bool readSVOFromStream(uint64_t streamLength, QDataStream& inputStream);
     bool readJSONFromStream(uint64_t streamLength, QDataStream& inputStream, const QString& marketplaceID="");


### PR DESCRIPTION
- Add support for serverless domains via HTTP/HTTPS.
- Fix missing "no connection" dialog for invalid serverless domains.
- Add support for serverless domains via FILE and HTTP/HTTPS in the --url command line parameter.

Issue: https://github.com/kasenvr/project-athena/issues/106
