### PR TITLE
Makes simplified nametag a default script

### DIFF
--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -39,7 +39,8 @@ var DEFAULT_SCRIPTS_COMBINED = [
 var DEFAULT_SCRIPTS_SEPARATE = [
     "system/controllers/controllerScripts.js",
     "communityModules/notificationCore/notificationCore.js",
-    "communityModules/chat/FloofChat.js"
+    "communityModules/chat/FloofChat.js",
+    "simplifiedUI/ui/simplifiedNametag/simplifiedNametag.js"
     //"system/chat.js"
 ];
 

--- a/scripts/simplifiedUI/ui/simplifiedNametag/simplifiedNametag.js
+++ b/scripts/simplifiedUI/ui/simplifiedNametag/simplifiedNametag.js
@@ -8,10 +8,11 @@
 //
 //    Click on someone to get a nametag for them
 //    
-var PickRayController = Script.require('./resources/modules/pickRayController.js');
+var PickRayController = Script.require('./resources/modules/pickRayController.js?' + Date.now());
 var NameTagListManager = Script.require('./resources/modules/nameTagListManager.js');
 var pickRayController = new PickRayController();
 var nameTagListManager = new NameTagListManager();
+var altKeyPressed = false;
 
 // Handles avatar being solo'd
 pickRayController
@@ -24,7 +25,9 @@ pickRayController
 
 
 function selectAvatar(uuid, intersection) {
-    nameTagListManager.handleSelect(uuid, intersection);
+    if (!altKeyPressed) {
+        nameTagListManager.handleSelect(uuid, intersection);
+    }
 }
 
 
@@ -46,6 +49,18 @@ function onAvatarAdded(uuid) {
     nameTagListManager.maybeAdd(uuid);
 }
 
+function blockedKeysPressed(event) {
+    if (event.isAlt) {
+        altKeyPressed = true;
+    }
+}
+
+function blockedKeysReleased(event) {
+    if (!event.isAlt) {
+        altKeyPressed = false;
+    }
+}
+
 
 // Create a new nametag list manager, connect signals, and return back a new Nametag object.
 var avatarNametagMode;
@@ -57,6 +72,8 @@ function startup() {
     Window.domainChanged.connect(onDomainChange);
     AvatarManager.avatarRemovedEvent.connect(onAvatarRemoved);
     AvatarManager.avatarAddedEvent.connect(onAvatarAdded);
+    Controller.keyPressEvent.connect(blockedKeysPressed);
+    Controller.keyReleaseEvent.connect(blockedKeysReleased);
 
     function NameTag() {}
     
@@ -67,7 +84,6 @@ function startup() {
     return new NameTag();
 }
 
-
 // Called when the script is closing
 function unload() {
     nameTagListManager.destroy();
@@ -75,6 +91,8 @@ function unload() {
     Window.domainChanged.disconnect(onDomainChange);
     AvatarManager.avatarRemovedEvent.disconnect(onAvatarRemoved);
     AvatarManager.avatarAddedEvent.disconnect(onAvatarAdded);
+    Controller.keyPressEvent.disconnect(blockedsKeyPressed);
+    Controller.keyReleaseEvent.disconnect(blockedKeysReleased);
 }
 
 
@@ -88,5 +106,6 @@ function handleAvatarNametagMode(newAvatarNameTagMode) {
 
 var nameTag = startup();
 
-module.exports = nameTag;
-
+// if (module) {
+//     module.exports = nameTag;
+// }

--- a/scripts/simplifiedUI/ui/simplifiedNametag/simplifiedNametag.js
+++ b/scripts/simplifiedUI/ui/simplifiedNametag/simplifiedNametag.js
@@ -106,6 +106,8 @@ function handleAvatarNametagMode(newAvatarNameTagMode) {
 
 var nameTag = startup();
 
-// if (module) {
-//     module.exports = nameTag;
-// }
+try {
+    module.exports = nameTag;
+} catch (e) {
+    // module doesn't exist when script run outside of simplified UI.
+}

--- a/scripts/simplifiedUI/ui/simplifiedNametag/simplifiedNametag.js
+++ b/scripts/simplifiedUI/ui/simplifiedNametag/simplifiedNametag.js
@@ -8,7 +8,7 @@
 //
 //    Click on someone to get a nametag for them
 //    
-var PickRayController = Script.require('./resources/modules/pickRayController.js?' + Date.now());
+var PickRayController = Script.require('./resources/modules/pickRayController.js');
 var NameTagListManager = Script.require('./resources/modules/nameTagListManager.js');
 var pickRayController = new PickRayController();
 var nameTagListManager = new NameTagListManager();


### PR DESCRIPTION
Also made it so that it disables while using the inspect.js script.

Test plan:

When using the inspect.js script (holding the alt key), click on an avatar multiple times as you zoom in, out, and around that person. Ensure the nametag does not show up. Now stop using the inspect script, click on them again and observe that the nametags do show, timeout, or disappear when clicked again.