### PR TITLE
Adds menu toggle for beta default scripts

### DIFF
--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -54,6 +54,9 @@ if (Window.interstitialModeEnabled) {
 var MENU_CATEGORY = "Developer > Scripting";
 var MENU_ITEM = "Debug defaultScripts.js";
 
+var MENU_BETA_DEFAULT_SCRIPTS_CATEGORY = "Developer > Scripting";
+var MENU_BETA_DEFAULT_SCRIPTS_ITEM = "Enable Beta Default Scripts";
+
 var SETTINGS_KEY = '_debugDefaultScriptsIsChecked';
 var SETTINGS_KEY_BETA = '_betaDefaultScriptsIsChecked';
 var previousSetting = Settings.getValue(SETTINGS_KEY, false);
@@ -67,12 +70,29 @@ if (previousSetting === true || previousSetting === 'true') {
     previousSetting = true;
 }
 
+if (previousSettingBeta === '' || previousSettingBeta === false || previousSettingBeta === 'false') {
+    previousSettingBeta = false;
+}
+
+if (previousSettingBeta === true || previousSettingBeta === 'true') {
+    previousSettingBeta = true;
+}
+
 if (Menu.menuExists(MENU_CATEGORY) && !Menu.menuItemExists(MENU_CATEGORY, MENU_ITEM)) {
     Menu.addMenuItem({
         menuName: MENU_CATEGORY,
         menuItemName: MENU_ITEM,
         isCheckable: true,
         isChecked: previousSetting,
+    });
+}
+
+if (Menu.menuExists(MENU_BETA_DEFAULT_SCRIPTS_CATEGORY) && !Menu.menuItemExists(MENU_BETA_DEFAULT_SCRIPTS_CATEGORY, MENU_BETA_DEFAULT_SCRIPTS_ITEM)) {
+    Menu.addMenuItem({
+        menuName: MENU_BETA_DEFAULT_SCRIPTS_CATEGORY,
+        menuItemName: MENU_BETA_DEFAULT_SCRIPTS_ITEM,
+        isCheckable: true,
+        isChecked: previousSettingBeta,
     });
 }
 
@@ -169,17 +189,28 @@ function menuItemEvent(menuItem) {
             Settings.setValue(SETTINGS_KEY, false);
         }
         Menu.triggerOption("Reload All Scripts");
+    } 
+    if (menuItem === MENU_BETA_DEFAULT_SCRIPTS_ITEM) {
+        var isChecked = Menu.isOptionChecked(MENU_BETA_DEFAULT_SCRIPTS_ITEM);
+        if (isChecked === true) {
+            Settings.setValue(SETTINGS_KEY_BETA, true);
+        } else if (isChecked === false) {
+            Settings.setValue(SETTINGS_KEY_BETA, false);
+        }
     }
 }
 
-function removeMenuItem() {
+function removeMenuItems() {
     if (!Menu.isOptionChecked(MENU_ITEM)) {
         Menu.removeMenuItem(MENU_CATEGORY, MENU_ITEM);
+    }
+    if (!Menu.isOptionChecked(MENU_BETA_DEFAULT_SCRIPTS_ITEM)) {
+        Menu.removeMenuItem(MENU_BETA_DEFAULT_SCRIPTS_CATEGORY, MENU_BETA_DEFAULT_SCRIPTS_ITEM);
     }
 }
 
 Script.scriptEnding.connect(function () {
-    removeMenuItem();
+    removeMenuItems();
 });
 
 Menu.menuItemEvent.connect(menuItemEvent);

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -62,19 +62,19 @@ var SETTINGS_KEY_BETA = '_betaDefaultScriptsIsChecked';
 var previousSetting = Settings.getValue(SETTINGS_KEY, false);
 var previousSettingBeta = Settings.getValue(SETTINGS_KEY_BETA, false);
 
-if (previousSetting === '' || previousSetting === false || previousSetting === 'false') {
+if (previousSetting === '' || previousSetting === 'false') {
     previousSetting = false;
 }
 
-if (previousSetting === true || previousSetting === 'true') {
+if (previousSetting === 'true') {
     previousSetting = true;
 }
 
-if (previousSettingBeta === '' || previousSettingBeta === false || previousSettingBeta === 'false') {
+if (previousSettingBeta === '' || previousSettingBeta === 'false') {
     previousSettingBeta = false;
 }
 
-if (previousSettingBeta === true || previousSettingBeta === 'true') {
+if (previousSettingBeta === 'true') {
     previousSettingBeta = true;
 }
 

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -83,17 +83,18 @@ if (Menu.menuExists(MENU_CATEGORY) && !Menu.menuItemExists(MENU_CATEGORY, MENU_I
         menuName: MENU_CATEGORY,
         menuItemName: MENU_ITEM,
         isCheckable: true,
-        isChecked: previousSetting,
+        isChecked: previousSetting
     });
 }
 
-if (Menu.menuExists(MENU_BETA_DEFAULT_SCRIPTS_CATEGORY) && !Menu.menuItemExists(MENU_BETA_DEFAULT_SCRIPTS_CATEGORY, MENU_BETA_DEFAULT_SCRIPTS_ITEM)) {
-    Menu.addMenuItem({
-        menuName: MENU_BETA_DEFAULT_SCRIPTS_CATEGORY,
-        menuItemName: MENU_BETA_DEFAULT_SCRIPTS_ITEM,
-        isCheckable: true,
-        isChecked: previousSettingBeta,
-    });
+if (Menu.menuExists(MENU_BETA_DEFAULT_SCRIPTS_CATEGORY) 
+    && !Menu.menuItemExists(MENU_BETA_DEFAULT_SCRIPTS_CATEGORY, MENU_BETA_DEFAULT_SCRIPTS_ITEM)) {
+        Menu.addMenuItem({
+            menuName: MENU_BETA_DEFAULT_SCRIPTS_CATEGORY,
+            menuItemName: MENU_BETA_DEFAULT_SCRIPTS_ITEM,
+            isCheckable: true,
+            isChecked: previousSettingBeta
+        });
 }
 
 function loadSeparateDefaults() {
@@ -183,18 +184,18 @@ loadSeparateDefaults();
 function menuItemEvent(menuItem) {
     if (menuItem === MENU_ITEM) {
         var isChecked = Menu.isOptionChecked(MENU_ITEM);
-        if (isChecked === true) {
+        if (isChecked) {
             Settings.setValue(SETTINGS_KEY, true);
-        } else if (isChecked === false) {
+        } else {
             Settings.setValue(SETTINGS_KEY, false);
         }
         Menu.triggerOption("Reload All Scripts");
     } 
     if (menuItem === MENU_BETA_DEFAULT_SCRIPTS_ITEM) {
         var isChecked = Menu.isOptionChecked(MENU_BETA_DEFAULT_SCRIPTS_ITEM);
-        if (isChecked === true) {
+        if (isChecked) {
             Settings.setValue(SETTINGS_KEY_BETA, true);
-        } else if (isChecked === false) {
+        } else {
             Settings.setValue(SETTINGS_KEY_BETA, false);
         }
     }


### PR DESCRIPTION
To test: 

- Check the box under Developer > Scripting. 
- You will want to reload your default scripts, or restart the interface if you want to be extra sure. The floofchat app should now be loading from the URL instead of the folder. 
- Uncheck, reload the default scripts or restart the interface. The floofchat app should now be loading from the folder as before.