### PR TITLE
Update build docs.

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,9 +1,13 @@
+# General Build Information
+
+*Last Updated on December 21, 2019*
+
 ### OS Specific Build Guides
 
-* [BUILD_WIN.md](BUILD_WIN.md) - complete instructions for Windows.
-* [BUILD_OSX.md](BUILD_OSX.md) - additional instructions for OS X.
-* [BUILD_LINUX.md](BUILD_LINUX.md) - additional instructions for Linux.
-* [BUILD_ANDROID.md](BUILD_ANDROID.md) - additional instructions for Android
+* [Build Windows](BUILD_WIN.md) - complete instructions for Windows.
+* [Build Linux](BUILD_LINUX.md) - additional instructions for Linux.
+* [Build OSX](BUILD_OSX.md) - additional instructions for OS X.
+* [Build Android](BUILD_ANDROID.md) - additional instructions for Android
 
 ### Dependencies
 - [git](https://git-scm.com/downloads): >= 1.6  
@@ -21,10 +25,10 @@ These dependencies need not be installed manually. They are automatically downlo
 - [QuaZip](https://sourceforge.net/projects/quazip/files/quazip/):   0.7.3  
 - [SDL2](https://www.libsdl.org/download-2.0.php):   2.0.3  
 - [Intel Threading Building Blocks](https://www.threadingbuildingblocks.org/):   4.3  
-- [vcpkg](https://github.com/highfidelity/vcpkg):  
+- [vcpkg](https://github.com/hifi-archive/vcpkg):  
 - [VHACD](https://github.com/virneo/v-hacd)  
 - [zlib](http://www.zlib.net/):   1.28 (Win32 only)  
-- [nvtt](https://github.com/highfidelity/nvidia-texture-tools):   2.1.1 (customized)  
+- [nvtt](https://github.com/hifi-archive/nvidia-texture-tools):   2.1.1 (customized)  
 
 The above dependencies will be downloaded, built, linked and included automatically by CMake where we require them. The CMakeLists files that handle grabbing each of the following external dependencies can be found in the [cmake/externals folder](cmake/externals). The resulting downloads, source files and binaries will be placed in the `build/ext` folder in each of the subfolders for each external project.
 

--- a/BUILD_ANDROID.md
+++ b/BUILD_ANDROID.md
@@ -1,6 +1,10 @@
+# Build Android
+
+*Last Updated on December 21, 2019*
+
 Please read the [general build guide](BUILD.md) for information on building other platforms. Only Android specific instructions are found in this file. **Note that these instructions apply to building for Oculus Quest.**
 
-# Dependencies
+## Dependencies
 
 Building is currently supported on Windows, OSX and Linux, but developers intending to do work on the library dependencies are strongly urged to use 64 bit Linux as a build platform.
 
@@ -27,7 +31,7 @@ Still in the _SDK Tools_ tab, click _Show Package Details_. Select CMake 3.6.4. 
 
 Also, make sure the NDK installed version is 18 (or higher).
 
-# Environment
+## Environment
 
 ### Create a keystore in Android Studio
 Follow the directions [here](https://developer.android.com/studio/publish/app-signing#generate-key) to create a keystore file. You can save it anywhere (preferably not in the `hifi` folder).
@@ -64,7 +68,7 @@ The above code to suppress modules is not necessary, but will speed up the build
 
 `git clone https://github.com/kasenvr/project-athena.git`
 
-# Building & Running
+## Building & Running
 
 ### Building Modules
 
@@ -99,9 +103,9 @@ For the interface modules, you also need to select the activity to launch.
 
 Note the 's' in Permission**s**Checker for the Quest.
 
-Now you are able to run your module! Click the green play button in the top toolbar of Android Studio
-r
-# Troubleshooting
+Now you are able to run your module! Click the green play button in the top toolbar of Android Studio.
+
+## Troubleshooting
 
 To view a more complete debug log,
 

--- a/BUILD_LINUX.md
+++ b/BUILD_LINUX.md
@@ -1,4 +1,6 @@
-# Linux build guide
+# Build Linux
+
+*Last Updated on January 20, 2020*
 
 Please read the [general build guide](BUILD.md) for information on dependencies required for all platforms. Only Linux specific instructions are found in this file.
 
@@ -14,7 +16,7 @@ sudo add-apt-repository universe
 sudo apt-get update
 ```
 #### Install build tools:
--  First update the repositiories:  
+-  First update the repositories:  
 ```bash
 sudo apt-get update -y
 sudo apt-get upgrade -y
@@ -182,11 +184,11 @@ It can be worked around following these steps:
 `make`  
 `sudo make install`  
 
-1.. Link compiled files:  
+1. Link compiled files:  
 `sudo ln -s /usr/local/lib/libnvcore.so /usr/lib/libnvcore.so`  
 `sudo ln -s /usr/local/lib/libnvimage.so /usr/lib/libnvimage.so`  
 `sudo ln -s /usr/local/lib/libnvmath.so /usr/lib/libnvmath.so`  
 `sudo ln -s /usr/local/lib/libnvtt.so /usr/lib/libnvtt.so`  
 
-1.  After running this steps you can run interface:  
+1.  After running these steps you can run interface:  
 `interface/interface`  

--- a/BUILD_OSX.md
+++ b/BUILD_OSX.md
@@ -1,4 +1,8 @@
-Please read the [general build guide](BUILD.md) for information on dependencies required for all platforms. Only macOS specific instructions are found in this file.
+# Build OSX
+
+*Last Updated on April 30, 2019*
+
+Please read the [general build guide](BUILD.md) for information on dependencies required for all platforms. Only macOS specific instructions are found in this document.
 
 ### Homebrew
 

--- a/BUILD_WIN.md
+++ b/BUILD_WIN.md
@@ -1,5 +1,9 @@
-This is a stand-alone guide for creating your first Project Athena build for Windows 64-bit.  
-## Building Project Athena
+# Build Windows
+
+*Last Updated on January 13, 2020*
+
+This is a stand-alone guide for creating your first Vircadia build for Windows 64-bit.  
+
 Note: We are now using Visual Studio 2017 or 2019 and Qt 5.12.3.  
 If you are upgrading from previous versions, do a clean uninstall of those versions before going through this guide.  
 


### PR DESCRIPTION
TODO: We need absolute paths because when they are pulled into the docs, the links are of course broken as there is no actual repo there.