### PR TITLE
Separate user activity logging from crash logging

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -603,6 +603,12 @@ Menu::Menu() {
         false,
         &UserActivityLogger::getInstance(),
         SLOT(disable(bool)));
+    addCheckableActionToQMenuAndActionHash(networkMenu,
+        MenuOption::DisableCrashLogger,
+        0,
+        false,
+        &UserActivityLogger::getInstance(),
+        SLOT(crashDisable(bool)));
     addActionToQMenuAndActionHash(networkMenu, MenuOption::ShowDSConnectTable, 0,
         qApp, SLOT(loadDomainConnectionDialog()));
 

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -608,7 +608,7 @@ Menu::Menu() {
         0,
         false,
         &UserActivityLogger::getInstance(),
-        SLOT(crashDisable(bool)));
+        SLOT(crashMonitorDisable(bool)));
     addActionToQMenuAndActionHash(networkMenu, MenuOption::ShowDSConnectTable, 0,
         qApp, SLOT(loadDomainConnectionDialog()));
 

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -86,6 +86,7 @@ namespace MenuOption {
     const QString DeleteAvatarEntitiesBookmark = "Delete Avatar Entities Bookmark";
     const QString DeleteBookmark = "Delete Bookmark...";
     const QString DisableActivityLogger = "Disable Activity Logger";
+    const QString DisableCrashLogger = "Disable Crash Logger";
     const QString DisableEyelidAdjustment = "Disable Eyelid Adjustment";
     const QString DisableLightEntities = "Disable Light Entities";
     const QString DisplayCrashOptions = "Display Crash Options";

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -218,11 +218,11 @@ int main(int argc, const char* argv[]) {
     }
     qDebug() << "UserActivityLogger is enabled:" << ual.isEnabled();
 
-    if (ual.isCrashEnabled()) {
+    qDebug() << "Crash handler logger is enabled:" << ual.isCrashMonitorEnabled();
+    if (ual.isCrashMonitorEnabled()) {
         auto crashHandlerStarted = startCrashHandler(argv[0]);
         qDebug() << "Crash handler started:" << crashHandlerStarted;
     }
-
 
     const QString& applicationName = getInterfaceSharedMemoryName();
     bool instanceMightBeRunning = true;

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -218,7 +218,7 @@ int main(int argc, const char* argv[]) {
     }
     qDebug() << "UserActivityLogger is enabled:" << ual.isEnabled();
 
-    if (ual.isEnabled()) {
+    if (ual.isCrashEnabled()) {
         auto crashHandlerStarted = startCrashHandler(argv[0]);
         qDebug() << "Crash handler started:" << crashHandlerStarted;
     }

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -254,7 +254,15 @@ void setupPreferences() {
         auto setter = [](bool value) { Menu::getInstance()->setIsOptionChecked(MenuOption::DisableActivityLogger, !value); };
         preferences->addPreference(new CheckPreference("Privacy", "Send data - High Fidelity uses information provided by your "
                                 "client to improve the product through the logging of errors, tracking of usage patterns, "
-                                "installation and system details, and crash events. By allowing High Fidelity to collect "
+                                "installation and system details. By allowing High Fidelity to collect this information "
+                                "you are helping to improve the product. ", getter, setter));
+    }
+
+    {
+        auto getter = []()->bool { return !Menu::getInstance()->isOptionChecked(MenuOption::DisableCrashLogger); };
+        auto setter = [](bool value) { Menu::getInstance()->setIsOptionChecked(MenuOption::DisableCrashLogger, !value); };
+        preferences->addPreference(new CheckPreference("Privacy", "Send crashes - Vircadia uses information provided by your "
+                                "client to improve the product through crash events. By allowing Vircadia to collect "
                                 "this information you are helping to improve the product. ", getter, setter));
     }
 

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -259,7 +259,7 @@ void setupPreferences() {
     }
 
     {
-        auto getter = []()->bool { return !Menu::getInstance()->isOptionChecked(MenuOption::DisableCrashLogger); };
+        auto getter = []()->bool { return Menu::getInstance()->isOptionChecked(MenuOption::DisableCrashLogger); };
         auto setter = [](bool value) { Menu::getInstance()->setIsOptionChecked(MenuOption::DisableCrashLogger, !value); };
         preferences->addPreference(new CheckPreference("Privacy", "Send crashes - Vircadia uses information provided by your "
                                 "client to improve the product through crash reports. By allowing Vircadia to collect "

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -259,7 +259,7 @@ void setupPreferences() {
     }
 
     {
-        auto getter = []()->bool { return Menu::getInstance()->isOptionChecked(MenuOption::DisableCrashLogger); };
+        auto getter = []()->bool { return !Menu::getInstance()->isOptionChecked(MenuOption::DisableCrashLogger); };
         auto setter = [](bool value) { Menu::getInstance()->setIsOptionChecked(MenuOption::DisableCrashLogger, !value); };
         preferences->addPreference(new CheckPreference("Privacy", "Send crashes - Vircadia uses information provided by your "
                                 "client to improve the product through crash reports. By allowing Vircadia to collect "

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -262,7 +262,7 @@ void setupPreferences() {
         auto getter = []()->bool { return !Menu::getInstance()->isOptionChecked(MenuOption::DisableCrashLogger); };
         auto setter = [](bool value) { Menu::getInstance()->setIsOptionChecked(MenuOption::DisableCrashLogger, !value); };
         preferences->addPreference(new CheckPreference("Privacy", "Send crashes - Vircadia uses information provided by your "
-                                "client to improve the product through crash events. By allowing Vircadia to collect "
+                                "client to improve the product through crash reports. By allowing Vircadia to collect "
                                 "this information you are helping to improve the product. ", getter, setter));
     }
 

--- a/libraries/networking/src/UserActivityLogger.cpp
+++ b/libraries/networking/src/UserActivityLogger.cpp
@@ -34,8 +34,8 @@ void UserActivityLogger::disable(bool disable) {
     _disabled.set(disable);
 }
 
-void UserActivityLogger::crashDisable(bool disable) {
-    _crashDisabled.set(disable);
+void UserActivityLogger::crashMonitorDisable(bool disable) {
+    _crashMonitorDisabled.set(disable);
 }
 
 void UserActivityLogger::logAction(QString action, QJsonObject details, JSONCallbackParameters params) {

--- a/libraries/networking/src/UserActivityLogger.cpp
+++ b/libraries/networking/src/UserActivityLogger.cpp
@@ -34,6 +34,10 @@ void UserActivityLogger::disable(bool disable) {
     _disabled.set(disable);
 }
 
+void UserActivityLogger::crashDisable(bool disable) {
+    _crashDisabled.set(disable);
+}
+
 void UserActivityLogger::logAction(QString action, QJsonObject details, JSONCallbackParameters params) {
 //  qCDebug(networking).nospace() << ">>> UserActivityLogger::logAction(" << action << "," << QJsonDocument(details).toJson();
 // This logs what the UserActivityLogger would normally send to centralized servers.

--- a/libraries/networking/src/UserActivityLogger.h
+++ b/libraries/networking/src/UserActivityLogger.h
@@ -59,7 +59,7 @@ private slots:
 private:
     UserActivityLogger();
     Setting::Handle<bool> _disabled { "UserActivityLoggerDisabled", true };
-    Setting::Handle<bool> _crashDisabled { "CrashLoggerDisabled", true };
+    Setting::Handle<bool> _crashDisabled { "CrashLoggerDisabled", false };
 
     QElapsedTimer _timer;
 };

--- a/libraries/networking/src/UserActivityLogger.h
+++ b/libraries/networking/src/UserActivityLogger.h
@@ -35,11 +35,11 @@ public slots:
     bool isEnabled() { return !_disabled.get(); }
     bool isDisabledSettingSet() const { return _disabled.isSet(); }
 
-    bool isCrashEnabled() { return !_crashDisabled.get(); }
-    bool isCrashDisabledSettingSet() const { return _crashDisabled.isSet(); }
+    bool isCrashMonitorEnabled() { return !_crashMonitorDisabled.get(); }
+    bool isCrashMonitorDisabledSettingSet() const { return _crashMonitorDisabled.isSet(); }
 
     void disable(bool disable);
-    void crashDisable(bool disable);
+    void crashMonitorDisable(bool disable);
     void logAction(QString action, QJsonObject details = QJsonObject(), JSONCallbackParameters params = JSONCallbackParameters());
     
     void launch(QString applicationVersion, bool previousSessionCrashed, int previousSessionRuntime);
@@ -59,7 +59,7 @@ private slots:
 private:
     UserActivityLogger();
     Setting::Handle<bool> _disabled { "UserActivityLoggerDisabled", true };
-    Setting::Handle<bool> _crashDisabled { "CrashLoggerDisabled", false };
+    Setting::Handle<bool> _crashMonitorDisabled { "CrashMonitorDisabled", false };
 
     QElapsedTimer _timer;
 };

--- a/libraries/networking/src/UserActivityLogger.h
+++ b/libraries/networking/src/UserActivityLogger.h
@@ -35,7 +35,11 @@ public slots:
     bool isEnabled() { return !_disabled.get(); }
     bool isDisabledSettingSet() const { return _disabled.isSet(); }
 
+    bool isCrashEnabled() { return !_crashDisabled.get(); }
+    bool isCrashDisabledSettingSet() const { return _crashDisabled.isSet(); }
+
     void disable(bool disable);
+    void crashDisable(bool disable);
     void logAction(QString action, QJsonObject details = QJsonObject(), JSONCallbackParameters params = JSONCallbackParameters());
     
     void launch(QString applicationVersion, bool previousSessionCrashed, int previousSessionRuntime);
@@ -55,6 +59,7 @@ private slots:
 private:
     UserActivityLogger();
     Setting::Handle<bool> _disabled { "UserActivityLoggerDisabled", true };
+    Setting::Handle<bool> _crashDisabled { "CrashLoggerDisabled", true };
 
     QElapsedTimer _timer;
 };


### PR DESCRIPTION
separate user activity logging from crash logging, allowing people to say "no" to tracking while still sending crashes

Adds new setting CrashLoggerDisabled along with a new corresponding user preference.