### PR TITLE
Fix VS2019 (Version 16.5.1) builds

### DIFF
--- a/libraries/gpu/src/gpu/FrameReader.cpp
+++ b/libraries/gpu/src/gpu/FrameReader.cpp
@@ -734,7 +734,7 @@ BatchPointer Deserializer::readBatch(const json& node) {
 
     std::string batchName;
     if (node.count(keys::name)) {
-        batchName = node[keys::name];
+        batchName = node.value(keys::name, "");
     }
     BatchPointer result = std::make_shared<Batch>(batchName);
     auto& batch = *result;


### PR DESCRIPTION
Building in the latest version of Visual studio 2019 fails with a `'operator =' is ambigious` error. This small patch will fix the error.