### PR TITLE
Improve performance of MyAvatar::simulate when you have lots of descendants

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -3150,21 +3150,30 @@ glm::vec3 EntityTree::getUnscaledDimensionsForID(const QUuid& id) {
     return glm::vec3(1.0f);
 }
 
-void EntityTree::updateEntityQueryAACubeWorker(SpatiallyNestablePointer object, EntityEditPacketSender* packetSender,
+AACube EntityTree::updateEntityQueryAACubeWorker(SpatiallyNestablePointer object, EntityEditPacketSender* packetSender,
                                                MovingEntitiesOperator& moveOperator, bool force, bool tellServer) {
+    glm::vec3 min(FLT_MAX);
+    glm::vec3 max(-FLT_MAX);
+
     // if the queryBox has changed, tell the entity-server
     EntityItemPointer entity = std::dynamic_pointer_cast<EntityItem>(object);
     if (entity) {
         bool queryAACubeChanged = false;
         if (!entity->hasChildren()) {
-            // updateQueryAACube will also update all ancestors' AACubes, so we only need to call this for leaf nodes
-            queryAACubeChanged = entity->updateQueryAACube();
+            queryAACubeChanged = entity->updateQueryAACube(false);
+            AACube entityAACube = entity->getQueryAACube();
+            min = glm::min(min, entityAACube.getMinimumPoint());
+            max = glm::max(max, entityAACube.getMaximumPoint());
         } else {
-            AACube oldCube = entity->getQueryAACube();
             object->forEachChild([&](SpatiallyNestablePointer descendant) {
-                updateEntityQueryAACubeWorker(descendant, packetSender, moveOperator, force, tellServer);
+                AACube entityAACube = updateEntityQueryAACubeWorker(descendant, packetSender, moveOperator, force, tellServer);
+                min = glm::min(min, entityAACube.getMinimumPoint());
+                max = glm::max(max, entityAACube.getMaximumPoint());
             });
-            queryAACubeChanged = oldCube != entity->getQueryAACube();
+            queryAACubeChanged = entity->updateQueryAACubeWithDescendantAACube(AACube(Extents(min, max)), false);
+            AACube newCube = entity->getQueryAACube();
+            min = glm::min(min, newCube.getMinimumPoint());
+            max = glm::max(max, newCube.getMaximumPoint());
         }
 
         if (queryAACubeChanged || force) {
@@ -3173,9 +3182,10 @@ void EntityTree::updateEntityQueryAACubeWorker(SpatiallyNestablePointer object, 
             if (success) {
                 moveOperator.addEntityToMoveList(entity, newCube);
             }
-            // send an edit packet to update the entity-server about the queryAABox.  We do this for domain-hosted
-            // entities as well as for avatar-entities; the packet-sender will route the update accordingly
-            if (tellServer && packetSender && (entity->isDomainEntity() || entity->isAvatarEntity())) {
+            // send an edit packet to update the entity-server about the queryAABox.  We only do this for domain-hosted
+            // entities, as we don't want to flood the update pipeline with AvatarEntity updates, so we assume
+            // others have all info required to properly update queryAACube of AvatarEntities on their end
+            if (tellServer && packetSender && entity->isDomainEntity()) {
                 quint64 now = usecTimestampNow();
                 EntityItemProperties properties = entity->getProperties();
                 properties.setQueryAACubeDirty();
@@ -3190,7 +3200,16 @@ void EntityTree::updateEntityQueryAACubeWorker(SpatiallyNestablePointer object, 
             entity->markDirtyFlags(Simulation::DIRTY_POSITION);
             entityChanged(entity);
         }
+    } else {
+        // if we're called on a non-entity, we might still have entity descendants
+        object->forEachChild([&](SpatiallyNestablePointer descendant) {
+            AACube entityAACube = updateEntityQueryAACubeWorker(descendant, packetSender, moveOperator, force, tellServer);
+            min = glm::min(min, entityAACube.getMinimumPoint());
+            max = glm::max(max, entityAACube.getMaximumPoint());
+        });
     }
+
+    return AACube(Extents(min, max));
 }
 
 void EntityTree::updateEntityQueryAACube(SpatiallyNestablePointer object, EntityEditPacketSender* packetSender,

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -397,8 +397,9 @@ private:
 
     std::map<QString, QString> _namedPaths;
 
-    void updateEntityQueryAACubeWorker(SpatiallyNestablePointer object, EntityEditPacketSender* packetSender,
-                                       MovingEntitiesOperator& moveOperator, bool force, bool tellServer);
+    // Return an AACube containing object and all its entity descendants
+    AACube updateEntityQueryAACubeWorker(SpatiallyNestablePointer object, EntityEditPacketSender* packetSender,
+                                         MovingEntitiesOperator& moveOperator, bool force, bool tellServer);
 };
 
 void convertGrabUserDataToProperties(EntityItemProperties& properties);

--- a/libraries/shared/src/SpatiallyNestable.h
+++ b/libraries/shared/src/SpatiallyNestable.h
@@ -117,8 +117,10 @@ public:
 
     virtual void setQueryAACube(const AACube& queryAACube);
     virtual bool queryAACubeNeedsUpdate() const;
+    virtual bool queryAACubeNeedsUpdateWithDescendantAACube(const AACube& descendantAACube) const;
     virtual bool shouldPuffQueryAACube() const { return false; }
-    bool updateQueryAACube();
+    bool updateQueryAACube(bool updateParent = true);
+    bool updateQueryAACubeWithDescendantAACube(const AACube& descendentAACube, bool updateParent = true);
     void forceQueryAACubeUpdate() { _queryAACubeSet = false; }
     virtual AACube getQueryAACube(bool& success) const;
     virtual AACube getQueryAACube() const;


### PR DESCRIPTION
Run [this script](https://gist.githubusercontent.com/HifiExperiments/8f79e199b1f132f06e512a18f91c3b53/raw/3ea3bfcee0fdd5849eba8f53394eafd510f6724f/ModelParenting.js).  You'll see a bunch of mannequins in front of you.  Press 'o'.  This will make the bottom model a child of your avatar.  On master, your framerate will basically go to 0.  Now, your framerate will still drop, but not nearly as much, and interface should still be usable.