### PR TITLE
Make custom Qt builds work on unsupported Ubuntu distributions

### DIFF
--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -301,8 +301,10 @@ endif()
                         url = self.assets_url + '/dependencies/vcpkg/qt5-install-5.12.6-ubuntu-19.10.tar.xz'
                     elif u_major > 18 and ( u_major != 19 and u_minor != 4):
                         print("We don't support " + distro.name(pretty=True) + " yet. Perhaps consider helping us out?")
+                        return
                     else:
                         print("Sorry, " + distro.name(pretty=True) + " is old and won't be officially supported. Please consider upgrading.");
+                        return
                 else:
                     print("Sorry, " + distro.name(pretty=True) + " is not supported. Please consider helping us out.")
                     print("It's also possible to build Qt for your distribution, please see the documentation at:")


### PR DESCRIPTION
Okay, this is a bit embarrassing.

In the current code, Ubuntu 20.04 (and other versions without prebuilt packages) won't work right. This is because due to the lack of a "return" statement, the code will emit the error, then try to download the URL "NOT DEFINED", even if everything is set up to use an externally provided Qt.

The overall way this works is far from ideal, but proper fixes will need to wait until the master merge is complete, because those have a fair amount of changes to the build system. This will allow things to work with minimal changes meanwhile.
