### PR TITLE
Add community-apps repo to default QML whitelist.

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3167,7 +3167,7 @@ void Application::showLoginScreen() {
 #endif
 }
 
-static const QUrl AUTHORIZED_EXTERNAL_QML_SOURCE { "https://kasenvr.github.io/community-apps/applications" };
+static const QUrl AUTHORIZED_EXTERNAL_QML_SOURCE { "https://cdn.vircadia.com/community-apps/applications" };
 
 void Application::initializeUi() {
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3186,18 +3186,14 @@ void Application::initializeUi() {
             safeURLS += settingsSafeURLS;
 
             // END PULL SAFEURLS FROM INTERFACE.JSON Settings
-
-            bool isInWhitelist = false;  // assume unsafe
             
             if (AUTHORIZED_EXTERNAL_QML_SOURCE.isParentOf(url)) {
-                isInWhitelist = true;
                 return true;
             } else {
                 for (const auto& str : safeURLS) {
                     if (!str.isEmpty() && str.endsWith(".qml") && url.toString().endsWith(".qml") &&
                         url.toString().startsWith(str)) {
                         qCDebug(interfaceapp) << "Found matching url!" << url.host();
-                        isInWhitelist = true;
                         return true;
                     }
                 }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3167,7 +3167,7 @@ void Application::showLoginScreen() {
 #endif
 }
 
-static const QUrl AUTHORIZED_EXTERNAL_QML_SOURCE { "https://content.highfidelity.com/Experiences/Releases" };
+static const QUrl AUTHORIZED_EXTERNAL_QML_SOURCE { "https://kasenvr.github.io/community-apps/applications" };
 
 void Application::initializeUi() {
 
@@ -3188,12 +3188,18 @@ void Application::initializeUi() {
             // END PULL SAFEURLS FROM INTERFACE.JSON Settings
 
             bool isInWhitelist = false;  // assume unsafe
-            for (const auto& str : safeURLS) {
-                if (!str.isEmpty() && str.endsWith(".qml") && url.toString().endsWith(".qml") &&
-                    url.toString().startsWith(str)) {
-                    qCDebug(interfaceapp) << "Found matching url!" << url.host();
-                    isInWhitelist = true;
-                    return true;
+            
+            if (AUTHORIZED_EXTERNAL_QML_SOURCE.isParentOf(url)) {
+                isInWhitelist = true;
+                return true;
+            } else {
+                for (const auto& str : safeURLS) {
+                    if (!str.isEmpty() && str.endsWith(".qml") && url.toString().endsWith(".qml") &&
+                        url.toString().startsWith(str)) {
+                        qCDebug(interfaceapp) << "Found matching url!" << url.host();
+                        isInWhitelist = true;
+                        return true;
+                    }
                 }
             }
 


### PR DESCRIPTION
This cannot be tested until there is a QML based app in the community-apps repo, we should get the Spectator cam merged first in order to test this.

Closes #295 