### PR TITLE
[debug crash] unnecessary out-of-bounds array reference on load

### DIFF
--- a/libraries/animation/src/AnimBlendDirectional.cpp
+++ b/libraries/animation/src/AnimBlendDirectional.cpp
@@ -96,7 +96,9 @@ const AnimPoseVec& AnimBlendDirectional::evaluate(const AnimVariantMap& animVars
             }
         }
         _poses.resize(minSize);
-        blend4(minSize, &poseVecs[0][0], &poseVecs[1][0], &poseVecs[2][0], &poseVecs[3][0], &alphas[0], &_poses[0]);
+        if (minSize) {
+            blend4(minSize, &poseVecs[0][0], &poseVecs[1][0], &poseVecs[2][0], &poseVecs[3][0], &alphas[0], &_poses[0]);
+        }
 
         // animation stack debug stats
         for (int i = 0; i < 9; i++) {

--- a/libraries/animation/src/AnimBlendDirectional.cpp
+++ b/libraries/animation/src/AnimBlendDirectional.cpp
@@ -96,7 +96,7 @@ const AnimPoseVec& AnimBlendDirectional::evaluate(const AnimVariantMap& animVars
             }
         }
         _poses.resize(minSize);
-        if (minSize) {
+        if (minSize > 0) {
             blend4(minSize, &poseVecs[0][0], &poseVecs[1][0], &poseVecs[2][0], &poseVecs[3][0], &alphas[0], &_poses[0]);
         }
 


### PR DESCRIPTION
This patch skips a call to blend4 when minSize==0.  In this instance the function doesn't do anything (it's a for() loop that runs "minSize" times) and assembling the parameters retrieves the first value from four vectors, one of which we already know is empty if minSize==0.