### PR TITLE
[shutdown-deadlock] Restructure ContextAwareProfile from polling to notifications

### DIFF
--- a/libraries/ui/src/ui/types/ContextAwareProfile.cpp
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.cpp
@@ -22,19 +22,19 @@
 
 static const QString RESTRICTED_FLAG_PROPERTY = "RestrictFileAccess";
 
-QReadWriteLock ContextAwareProfile::gl_contextMapProtect;
-ContextAwareProfile::ContextMap ContextAwareProfile::gl_contextMap;
+QReadWriteLock ContextAwareProfile::_global_contextMapProtect;
+ContextAwareProfile::ContextMap ContextAwareProfile::_global_contextMap;
 
 ContextAwareProfile::ContextAwareProfile(QQmlContext* context) : ContextAwareProfileParent(context), _context(context) {
     assert(context);
 
     {   // register our object for future updates
-        QWriteLocker guard(&gl_contextMapProtect);
-        ContextMap::iterator setLookup = gl_contextMap.find(_context);
-        if (setLookup == gl_contextMap.end()) {
-            setLookup = gl_contextMap.insert(_context, ContextAwareProfileSet());
+        QWriteLocker guard(&_global_contextMapProtect);
+        ContextMap::iterator setLookup = _global_contextMap.find(_context);
+        if (setLookup == _global_contextMap.end()) {
+            setLookup = _global_contextMap.insert(_context, ContextAwareProfileSet());
         }
-        assert(setLookup != gl_contextMap.end());
+        assert(setLookup != _global_contextMap.end());
         ContextAwareProfileSet& profileSet = setLookup.value();
         assert(profileSet.find(this) == profileSet.end());
         profileSet.insert(this);
@@ -45,15 +45,15 @@ ContextAwareProfile::ContextAwareProfile(QQmlContext* context) : ContextAwarePro
 
 ContextAwareProfile::~ContextAwareProfile() {
     {  // deregister our object
-        QWriteLocker guard(&gl_contextMapProtect);
-        ContextMap::iterator setLookup = gl_contextMap.find(_context);
-        assert(setLookup != gl_contextMap.end());
-        if (setLookup != gl_contextMap.end()) {
+        QWriteLocker guard(&_global_contextMapProtect);
+        ContextMap::iterator setLookup = _global_contextMap.find(_context);
+        assert(setLookup != _global_contextMap.end());
+        if (setLookup != _global_contextMap.end()) {
             ContextAwareProfileSet& profileSet = setLookup.value();
             assert(profileSet.find(this) != profileSet.end());
             profileSet.remove(this);
             if (profileSet.isEmpty()) {
-                gl_contextMap.erase(setLookup);
+                _global_contextMap.erase(setLookup);
             }
         }
     }
@@ -65,15 +65,13 @@ void ContextAwareProfile::restrictContext(QQmlContext* context, bool restrict) {
     context->setContextProperty(RESTRICTED_FLAG_PROPERTY, restrict);
 
     // broadcast the new value to any registered ContextAwareProfile objects
-    {  // deregister our object
-        QReadLocker guard(&gl_contextMapProtect);
-        ContextMap::const_iterator setLookup = gl_contextMap.find(context);
-        if (setLookup != gl_contextMap.end()) {
-            const ContextAwareProfileSet& profileSet = setLookup.value();
-            for (ContextAwareProfileSet::const_iterator profileIterator = profileSet.begin();
-                 profileIterator != profileSet.end(); profileIterator++) {
-                (*profileIterator)->onIsRestrictedChanged(restrict);
-            }
+    QReadLocker guard(&_global_contextMapProtect);
+    ContextMap::const_iterator setLookup = _global_contextMap.find(context);
+    if (setLookup != _global_contextMap.end()) {
+        const ContextAwareProfileSet& profileSet = setLookup.value();
+        for (ContextAwareProfileSet::const_iterator profileIterator = profileSet.begin();
+                profileIterator != profileSet.end(); profileIterator++) {
+            (*profileIterator)->onIsRestrictedChanged(restrict);
         }
     }
 }

--- a/libraries/ui/src/ui/types/ContextAwareProfile.cpp
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.cpp
@@ -38,12 +38,12 @@ RestrictedContextMonitor::TSharedPointer RestrictedContextMonitor::getMonitor(QQ
     gl_monitorMapProtect.lock();
     TMonitorMap::const_iterator lookup = gl_monitorMap.find(context);
     if (lookup != gl_monitorMap.end()) {
-        monitor = lookup->second.lock();
+        monitor = lookup.value().lock();
         assert(monitor);
     } else if(createIfMissing) {
         monitor = TSharedPointer::create(context);
         monitor->_selfPointer = monitor;
-        gl_monitorMap.insert(TMonitorMap::value_type(context, monitor));
+        gl_monitorMap.insert(context, monitor);
     }
     gl_monitorMapProtect.unlock();
     return monitor;

--- a/libraries/ui/src/ui/types/ContextAwareProfile.h
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.h
@@ -12,7 +12,7 @@
 #define hifi_ContextAwareProfile_h
 
 #include <atomic>
-#include <QtCore/QMap>
+#include <QtCore/QHash>
 #include <QtCore/QReadWriteLock>
 #include <QtCore/QSet>
 #include <QtCore/QSharedPointer>
@@ -50,17 +50,18 @@ protected:
 
     ContextAwareProfile(QQmlContext* parent);
     ~ContextAwareProfile();
-    void onIsRestrictedChanged(bool newValue);
+
+private:
+    typedef QSet<ContextAwareProfile*> ContextAwareProfileSet;
+    typedef QHash<QQmlContext*, ContextAwareProfileSet> ContextMap;
 
     QQmlContext* _context{ nullptr };
     std::atomic<bool> _isRestricted{ false };
 
-private:
-    typedef QSet<ContextAwareProfile*> ContextAwareProfileSet;
-    typedef QMap<QQmlContext*, ContextAwareProfileSet> ContextMap;
+    static QReadWriteLock _global_contextMapProtect;
+    static ContextMap _global_contextMap;
 
-    static QReadWriteLock gl_contextMapProtect;
-    static ContextMap gl_contextMap;
+    void onIsRestrictedChanged(bool newValue);
 };
 
 #endif // hifi_FileTypeProfile_h

--- a/libraries/ui/src/ui/types/ContextAwareProfile.h
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.h
@@ -12,6 +12,7 @@
 #define hifi_ContextAwareProfile_h
 
 #include <QtCore/QtGlobal>
+#include <QtCore/QMap>
 #include <QtCore/QMutex>
 #include <QtCore/QSharedPointer>
 
@@ -53,7 +54,7 @@ public:
     bool _isUninitialized{ true };
 
 private:
-    typedef std::map<QQmlContext*, TWeakPointer> TMonitorMap;
+    typedef QMap<QQmlContext*, TWeakPointer> TMonitorMap;
 
     static QMutex gl_monitorMapProtect;
     static TMonitorMap gl_monitorMap;

--- a/libraries/ui/src/ui/types/ContextAwareProfile.h
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.h
@@ -13,6 +13,7 @@
 
 #include <QtCore/QtGlobal>
 #include <QtCore/QMutex>
+#include <QtCore/QSharedPointer>
 
 #if !defined(Q_OS_ANDROID)
 #include <QtWebEngine/QQuickWebEngineProfile>
@@ -34,25 +35,25 @@ class QQmlContext;
 class RestrictedContextMonitor : public QObject {
     Q_OBJECT
 public:
-    typedef std::shared_ptr<RestrictedContextMonitor> TSharedPtr;
-    typedef std::weak_ptr<RestrictedContextMonitor> TWeakPtr;
+    typedef QSharedPointer<RestrictedContextMonitor> TSharedPointer;
+    typedef QWeakPointer<RestrictedContextMonitor> TWeakPointer;
 
-    inline RestrictedContextMonitor(QQmlContext* c) : context(c) {}
+    inline RestrictedContextMonitor(QQmlContext* c) : _context(c) {}
     ~RestrictedContextMonitor();
 
-    static TSharedPtr getMonitor(QQmlContext* context, bool createIfMissing);
+    static TSharedPointer getMonitor(QQmlContext* context, bool createIfMissing);
 
 signals:
     void onIsRestrictedChanged(bool newValue);
 
 public:
-    TWeakPtr selfPtr;
-    QQmlContext* context{ nullptr };
-    bool isRestricted{ true };
-    bool isUninitialized{ true };
+    TWeakPointer _selfPointer;
+    QQmlContext* _context{ nullptr };
+    bool _isRestricted{ true };
+    bool _isUninitialized{ true };
 
 private:
-    typedef std::map<QQmlContext*, TWeakPtr> TMonitorMap;
+    typedef std::map<QQmlContext*, TWeakPointer> TMonitorMap;
 
     static QMutex gl_monitorMapProtect;
     static TMonitorMap gl_monitorMap;
@@ -82,7 +83,7 @@ private slots:
     void onIsRestrictedChanged(bool newValue);
 
 private:
-    RestrictedContextMonitor::TSharedPtr _monitor;
+    RestrictedContextMonitor::TSharedPointer _monitor;
 };
 
 #endif // hifi_FileTypeProfile_h

--- a/libraries/ui/src/ui/types/ContextAwareProfile.h
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.h
@@ -58,10 +58,8 @@ private:
     QQmlContext* _context{ nullptr };
     std::atomic<bool> _isRestricted{ false };
 
-    static QReadWriteLock _global_contextMapProtect;
-    static ContextMap _global_contextMap;
-
-    void onIsRestrictedChanged(bool newValue);
+    static QReadWriteLock _contextMapProtect;
+    static ContextMap _contextMap;
 };
 
 #endif // hifi_FileTypeProfile_h


### PR DESCRIPTION
This concerns a class responsible for checking if webpages are restricted from making outside requests.  The previous implementation would do a (cross-thread blocking) retrieval of a QML property (with a one-second cache).  Unfortunately I have been seeing (from debugger, so not necessarily a real-world situation) a consistent deadlock where the value was being retrieved during app shutdown.

The new approach sets up a signal+slot attempting to forward any changes to RestrictFileAccess at the time they occur, the only time the QML value is retrieved is at the point of class construction.  Retrieving the value is done from a QAtomicInt with no blocking.

The only change in behavior should be that RestrictFileAccess is no longer (consistently) changeable from QML script.  Is this something that QML scripts would do?