### PR TITLE
Improve information sent to Sentry on crashes

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1083,8 +1083,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     {
         // identify gpu as early as possible to help identify OpenGL initialization errors.
         auto gpuIdent = GPUIdent::getInstance();
-        setCrashAnnotation("gpu_name", gpuIdent->getName().toStdString());
-        setCrashAnnotation("gpu_driver", gpuIdent->getDriver().toStdString());
+        setCrashAnnotation("sentry[contexts][gpu][name]", gpuIdent->getName().toStdString());
+        setCrashAnnotation("sentry[contexts][gpu][version]", gpuIdent->getDriver().toStdString());
         setCrashAnnotation("gpu_memory", std::to_string(gpuIdent->getMemory()));
     }
 
@@ -7054,7 +7054,7 @@ void Application::updateWindowTitle() const {
         nodeList->getDomainHandler().isConnected() ? "" : " (NOT CONNECTED)";
     QString username = accountManager->getAccountInfo().getUsername();
 
-    setCrashAnnotation("username", username.toStdString());
+    setCrashAnnotation("sentry[user][username]", username.toStdString());
 
     QString currentPlaceName;
     if (isServerlessMode()) {

--- a/interface/src/CrashHandler_Crashpad.cpp
+++ b/interface/src/CrashHandler_Crashpad.cpp
@@ -84,10 +84,9 @@ bool startCrashHandler(std::string appPath) {
     std::vector<std::string> arguments;
 
     std::map<std::string, std::string> annotations;
-    annotations["token"] = BACKTRACE_TOKEN;
-    annotations["format"] = "minidump";
-    annotations["version"] = BuildInfo::VERSION.toStdString();
-    annotations["build_number"] = BuildInfo::BUILD_NUMBER.toStdString();
+    annotations["sentry[release]"] = BACKTRACE_TOKEN;
+    annotations["sentry[contexts][app][app_version]"] = BuildInfo::VERSION.toStdString();
+    annotations["sentry[contexts][app][app_build]"] = BuildInfo::BUILD_NUMBER.toStdString();
     annotations["build_type"] = BuildInfo::BUILD_TYPE_STRING.toStdString();
 
     auto machineFingerPrint = uuidStringWithoutCurlyBraces(FingerprintUtils::getMachineFingerprint());


### PR DESCRIPTION
Currently the information that is sent when Interface crashes is not tuned to Sentry; because of this most of the information is simply included at the bottom of the dump.  This tweaks the names of the attributes to give hints on how Sentry should interpret them.