### PR TITLE
Attempt to fix #337 by ensuring the object is marked as dead.

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -784,6 +784,7 @@ void EntityTree::processRemovedEntities(const DeleteEntityOperator& theOperator)
             }
         }
         if (theEntity->isSimulated()) {
+            theEntity->die();
             _simulation->prepareEntityForDelete(theEntity);
         }
     }


### PR DESCRIPTION
Currently interface crashes very quickly on master when built with debug enabled, see #337 

This patch attempts to fix that, and it seems to work, but issues almost instantly crop up elsewhere, somewhere from the scripting engine apparently. So this fix could well be completely incorrect.

Submitting this for feedback.
