### PR TITLE
Disable "grabbable" property by default

### DIFF
--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -1409,7 +1409,7 @@ function setupModelMenus() {
         menuItemName: MENU_CREATE_ENTITIES_GRABBABLE,
         afterItem: "Unparent Entity",
         isCheckable: true,
-        isChecked: Settings.getValue(SETTING_EDIT_PREFIX + MENU_CREATE_ENTITIES_GRABBABLE, true)
+        isChecked: Settings.getValue(SETTING_EDIT_PREFIX + MENU_CREATE_ENTITIES_GRABBABLE, false)
     });
 
     Menu.addMenuItem({


### PR DESCRIPTION
Changed the code so that no entities are grabbable by default anymore.
As I cannot see why anyone would want this unless this option was easily toggleable, I completely removed that part of the code.
Tested if it works and doesn't break anything that might be related to it.
Closes #209 