### PR TITLE
Remove all uses of QString::null

### DIFF
--- a/launchers/qt/src/BuildsRequest.h
+++ b/launchers/qt/src/BuildsRequest.h
@@ -4,10 +4,10 @@
 #include <QNetworkAccessManager>
 
 struct Build {
-    QString tag{ QString::null };
+    QString tag;
     int latestVersion{ 0 };
     int buildNumber{ 0 };
-    QString installerZipURL{ QString::null };
+    QString installerZipURL;
 };
 
 struct Builds {

--- a/launchers/qt/src/LauncherState.cpp
+++ b/launchers/qt/src/LauncherState.cpp
@@ -244,7 +244,7 @@ void LauncherState::getCurrentClientVersion() {
     if (match.hasMatch()) {
         _currentClientVersion = match.captured("version");
     } else {
-        _currentClientVersion = QString::null;
+        _currentClientVersion.clear();
     }
     qDebug() << "Current client version is: " << _currentClientVersion;
 

--- a/launchers/qt/src/LauncherState.h
+++ b/launchers/qt/src/LauncherState.h
@@ -176,7 +176,7 @@ private:
     QString _displayName;
     QString _applicationErrorMessage;
     QString _currentClientVersion;
-    QString _buildTag { QString::null };
+    QString _buildTag;
     QString _contentCacheURL;
     QString _loginTokenResponse;
     QFile _clientZipFile;

--- a/launchers/qt/src/UserSettingsRequest.h
+++ b/launchers/qt/src/UserSettingsRequest.h
@@ -6,7 +6,7 @@
 #include "LoginRequest.h"
 
 struct UserSettings {
-    QString homeLocation{ QString::null };
+    QString homeLocation;
 };
 
 class UserSettingsRequest : public QObject {

--- a/libraries/shared/src/PathUtils.h
+++ b/libraries/shared/src/PathUtils.h
@@ -58,7 +58,7 @@ public:
     static QString generateTemporaryDir();
     static bool deleteMyTemporaryDir(QString dirName);
 
-    static int removeTemporaryApplicationDirs(QString appName = QString::null);
+    static int removeTemporaryApplicationDirs(QString appName = QString());
 
     static Qt::CaseSensitivity getFSCaseSensitivity();
     static QString stripFilename(const QUrl& url);

--- a/tools/oven/src/BakerCLI.h
+++ b/tools/oven/src/BakerCLI.h
@@ -34,7 +34,7 @@ public:
     BakerCLI(OvenCLIApplication* parent);
 
 public slots:
-    void bakeFile(QUrl inputUrl, const QString& outputPath, const QString& type = QString::null);
+    void bakeFile(QUrl inputUrl, const QString& outputPath, const QString& type = QString());
 
 private slots:
     void handleFinishedBaker();  

--- a/tools/oven/src/OvenCLIApplication.cpp
+++ b/tools/oven/src/OvenCLIApplication.cpp
@@ -85,7 +85,7 @@ void OvenCLIApplication::parseCommandLine(int argc, char* argv[]) {
     _inputUrlParameter = QDir::fromNativeSeparators(parser.value(CLI_INPUT_PARAMETER));
     _outputUrlParameter = QDir::fromNativeSeparators(parser.value(CLI_OUTPUT_PARAMETER));
 
-    _typeParameter = parser.isSet(CLI_TYPE_PARAMETER) ? parser.value(CLI_TYPE_PARAMETER) : QString::null;
+    _typeParameter = parser.isSet(CLI_TYPE_PARAMETER) ? parser.value(CLI_TYPE_PARAMETER) : QString();
 
     if (parser.isSet(CLI_DISABLE_TEXTURE_COMPRESSION_PARAMETER)) {
         qDebug() << "Disabling texture compression";


### PR DESCRIPTION
It's deprecated and produces a warning on Qt 5.14. It produces lots of:

    'QString::null' is deprecated: use QString() [-Wdeprecated-declarations]

when compiling.
