### PR TITLE
Fix warnings emitted by GCC

### DIFF
--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -1196,7 +1196,7 @@ Node::LocalID DomainGatekeeper::findOrCreateLocalID(const QUuid& uuid) {
         return existingLocalIDIt->second;
     }
 
-    assert(_localIDs.size() < std::numeric_limits<LocalIDs::value_type>::max() - 2);
+    assert(_localIDs.size() < (size_t)(std::numeric_limits<LocalIDs::value_type>::max() - 2));
 
     Node::LocalID newLocalID;
     do {

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -168,6 +168,7 @@ const btCollisionShape* OtherAvatar::createCollisionShape(int32_t jointIndex, bo
         }
         // Note: MultiSphereLow case really means: "skip fingers and use spheres for hands,
         // else fall through to MultiSphereHigh case"
+        /* fall-thru */
     case BodyLOD::MultiSphereHigh:
         computeDetailedShapeInfo(shapeInfo, jointIndex);
         break;

--- a/interface/src/ui/OctreeStatsDialog.cpp
+++ b/interface/src/ui/OctreeStatsDialog.cpp
@@ -424,6 +424,7 @@ void OctreeStatsDialog::showOctreeServersOfType(NodeType_t serverType) {
                                 extraDetails << "<br/>" << itemInfo.caption << " " << stats.getItemValue(item);
                             }
                         } // fall through... since MOST has all of MORE
+                        /* fall-thru */
                         case MORE: {
                             QString totalString = locale.toString((uint)stats.getTotalElements());
                             QString internalString = locale.toString((uint)stats.getTotalInternal());

--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -156,7 +156,6 @@ protected:
     std::mutex _materialsLock;
 
     quint64 _created;
-    QUuid _entityID;
 
     // The base class relies on comparing the model transform to the entity transform in order 
     // to trigger an update, so the member must not be visible to derived classes as a modifiable
@@ -166,6 +165,8 @@ protected:
     // i.e. to see if the rendering code needs to update because of a change in state of the 
     // entity.  This forces all the rendering code itself to be independent of the entity
     const EntityItemPointer _entity;
+
+    QUuid _entityID;
 };
 
 template <typename T>

--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
@@ -146,7 +146,7 @@ void ParticleEffectEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEn
         particleUniforms.rotateWithEntity = _particleProperties.rotateWithEntity ? 1 : 0;
     });
     // Update particle uniforms
-    memcpy(&_uniformBuffer.edit<ParticleUniforms>(), &particleUniforms, sizeof(ParticleUniforms));
+    _uniformBuffer.edit<ParticleUniforms>() = particleUniforms;
 }
 
 ItemKey ParticleEffectEntityRenderer::getKey() {

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
@@ -378,10 +378,10 @@ protected:
             TransformCamera _cams[2];
 
             Cameras(){};
-            Cameras(const TransformCamera& cam) { memcpy(_cams, &cam, sizeof(TransformCamera)); };
+            Cameras(const TransformCamera& cam) { _cams[0] = cam; };
             Cameras(const TransformCamera& camL, const TransformCamera& camR) {
-                memcpy(_cams, &camL, sizeof(TransformCamera));
-                memcpy(_cams + 1, &camR, sizeof(TransformCamera));
+                _cams[0] = camL;
+                _cams[1] = camR;
             };
         };
 

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendState.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendState.cpp
@@ -331,8 +331,7 @@ void GLBackend::do_setStateBlendFactor(const Batch& batch, size_t paramOffset) {
 
 void GLBackend::do_setStateScissorRect(const Batch& batch, size_t paramOffset) {
     Vec4i rect;
-    memcpy(&rect, batch.readData(batch._params[paramOffset]._uint), sizeof(Vec4i));
-
+    memcpy(glm::value_ptr(rect), batch.readData(batch._params[paramOffset]._uint), sizeof(Vec4i));
     if (_stereo.isStereo()) {
         rect.z /= 2;
         if (_stereo._pass) {

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendTransform.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendTransform.cpp
@@ -24,7 +24,7 @@ void GLBackend::do_setViewTransform(const Batch& batch, size_t paramOffset) {
 }
 
 void GLBackend::do_setProjectionTransform(const Batch& batch, size_t paramOffset) {
-    memcpy(&_transform._projection, batch.readData(batch._params[paramOffset]._uint), sizeof(Mat4));
+    memcpy(glm::value_ptr(_transform._projection), batch.readData(batch._params[paramOffset]._uint), sizeof(Mat4));
     _transform._invalidProj = true;
 }
 
@@ -35,7 +35,7 @@ void GLBackend::do_setProjectionJitter(const Batch& batch, size_t paramOffset) {
 }
 
 void GLBackend::do_setViewportTransform(const Batch& batch, size_t paramOffset) {
-    memcpy(&_transform._viewport, batch.readData(batch._params[paramOffset]._uint), sizeof(Vec4i));
+    memcpy(glm::value_ptr(_transform._viewport), batch.readData(batch._params[paramOffset]._uint), sizeof(Vec4i));
 
 #ifdef GPU_STEREO_DRAWCALL_INSTANCED
     {

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.cpp
@@ -440,6 +440,7 @@ QVector<glm::uint32> scriptable::ScriptableMeshPart::getFace(glm::uint32 faceInd
         if (faceIndex < getNumFaces()) {
             return getIndices().mid(faceIndex * getTopologyLength(), getTopologyLength());
         }
+    /* fall-thru */
     default: return QVector<glm::uint32>();
     }
 }

--- a/libraries/image/src/image/CubeMap.cpp
+++ b/libraries/image/src/image/CubeMap.cpp
@@ -99,10 +99,10 @@ public:
         const size_t offsetHL = hiCoords.x + loCoords.y * _lineStride;
         const size_t offsetLH = loCoords.x + hiCoords.y * _lineStride;
         const size_t offsetHH = hiCoords.x + hiCoords.y * _lineStride;
-        assert(offsetLL >= 0 && offsetLL < _lineStride * (_dims.y + 2 * EDGE_WIDTH));
-        assert(offsetHL >= 0 && offsetHL < _lineStride * (_dims.y + 2 * EDGE_WIDTH));
-        assert(offsetLH >= 0 && offsetLH < _lineStride * (_dims.y + 2 * EDGE_WIDTH));
-        assert(offsetHH >= 0 && offsetHH < _lineStride * (_dims.y + 2 * EDGE_WIDTH));
+        assert(offsetLL < _lineStride * (_dims.y + 2 * EDGE_WIDTH));
+        assert(offsetHL < _lineStride * (_dims.y + 2 * EDGE_WIDTH));
+        assert(offsetLH < _lineStride * (_dims.y + 2 * EDGE_WIDTH));
+        assert(offsetHH < _lineStride * (_dims.y + 2 * EDGE_WIDTH));
         glm::vec4 colorLL = pixels[offsetLL];
         glm::vec4 colorHL = pixels[offsetHL];
         glm::vec4 colorLH = pixels[offsetLH];

--- a/libraries/octree/src/OctreePacketData.cpp
+++ b/libraries/octree/src/OctreePacketData.cpp
@@ -16,6 +16,7 @@
 
 #include "OctreeLogging.h"
 #include "NumericalConstants.h"
+#include <glm/gtc/type_ptr.hpp>
 
 bool OctreePacketData::_debug = false;
 AtomicUIntStat OctreePacketData::_totalBytesOfOctalCodes { 0 };
@@ -702,17 +703,17 @@ void OctreePacketData::debugBytes() {
 }
 
 int OctreePacketData::unpackDataFromBytes(const unsigned char* dataBytes, glm::vec2& result) {
-    memcpy(&result, dataBytes, sizeof(result));
+    memcpy(glm::value_ptr(result), dataBytes, sizeof(result));
     return sizeof(result);
 }
 
 int OctreePacketData::unpackDataFromBytes(const unsigned char* dataBytes, glm::vec3& result) {
-    memcpy(&result, dataBytes, sizeof(result));
+    memcpy(glm::value_ptr(result), dataBytes, sizeof(result));
     return sizeof(result);
 }
 
 int OctreePacketData::unpackDataFromBytes(const unsigned char* dataBytes, glm::u8vec3& result) {
-    memcpy(&result, dataBytes, sizeof(result));
+    memcpy(glm::value_ptr(result), dataBytes, sizeof(result));
     return sizeof(result);
 }
 
@@ -743,7 +744,12 @@ int OctreePacketData::unpackDataFromBytes(const unsigned char *dataBytes, QVecto
     memcpy(&length, dataBytes, sizeof(uint16_t));
     dataBytes += sizeof(length);
     result.resize(length);
-    memcpy(result.data(), dataBytes, length * sizeof(glm::vec3));
+
+    for(int i=0;i<length;i++) {
+        memcpy(glm::value_ptr(result[i]), dataBytes, sizeof(glm::vec3));
+        dataBytes += sizeof(glm::vec3);
+    }
+
     return sizeof(uint16_t) + length * sizeof(glm::vec3);
 }
 

--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -691,6 +691,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                 break;
             case graphics::Material::CULL_FACE_MODE:
                 multiMaterial.setCullFaceMode(graphics::Material::DEFAULT_CULL_FACE_MODE);
+                break;
             case graphics::MaterialKey::ALBEDO_MAP_BIT:
                 if (schemaKey.isAlbedoMap()) {
                     drawMaterialTextures->setTexture(gr::Texture::MaterialAlbedo, textureCache->getWhiteTexture());

--- a/libraries/shared/src/BufferParser.h
+++ b/libraries/shared/src/BufferParser.h
@@ -99,7 +99,7 @@ template<>
 inline void BufferParser::readValue(QVector<glm::vec3>& result) {
     uint16_t length; readValue(length);
     result.resize(length);
-    for(int i=0;i<length;i++) {
+    for (int i=0; i<length; i++) {
         memcpy(glm::value_ptr(result[i]), _data + _offset + (sizeof(glm::vec3)*i), sizeof(glm::vec3) * length);
     }
 

--- a/libraries/shared/src/BufferParser.h
+++ b/libraries/shared/src/BufferParser.h
@@ -18,6 +18,7 @@
 #include "GLMHelpers.h"
 #include "ByteCountCoding.h"
 #include "PropertyFlags.h"
+#include <glm/gtc/type_ptr.hpp>
 
 class BufferParser {
 public:
@@ -98,7 +99,10 @@ template<>
 inline void BufferParser::readValue(QVector<glm::vec3>& result) {
     uint16_t length; readValue(length);
     result.resize(length);
-    memcpy(result.data(), _data + _offset, sizeof(glm::vec3) * length);
+    for(int i=0;i<length;i++) {
+        memcpy(glm::value_ptr(result[i]), _data + _offset + (sizeof(glm::vec3)*i), sizeof(glm::vec3) * length);
+    }
+
     _offset += sizeof(glm::vec3) * length;
 }
 

--- a/libraries/shared/src/GeometryUtil.cpp
+++ b/libraries/shared/src/GeometryUtil.cpp
@@ -620,7 +620,9 @@ void PolygonClip::clipToScreen(const glm::vec2* inputVertexArray, int inLength, 
     glm::vec2* tempVertexArrayB = new glm::vec2[maxLength];
 
     // set up our temporary arrays
-    memcpy(tempVertexArrayA, inputVertexArray, sizeof(glm::vec2) * inLength);
+    for(int i=0;i<inLength;i++) {
+        tempVertexArrayA[i] = inputVertexArray[i];
+    }
 
     // Left edge
     LineSegment2 edge;

--- a/libraries/shared/src/GeometryUtil.cpp
+++ b/libraries/shared/src/GeometryUtil.cpp
@@ -620,7 +620,7 @@ void PolygonClip::clipToScreen(const glm::vec2* inputVertexArray, int inLength, 
     glm::vec2* tempVertexArrayB = new glm::vec2[maxLength];
 
     // set up our temporary arrays
-    for(int i=0;i<inLength;i++) {
+    for (int i=0; i<inLength; i++) {
         tempVertexArrayA[i] = inputVertexArray[i];
     }
 

--- a/libraries/shared/src/avx2/BlendshapePacking_avx2.cpp
+++ b/libraries/shared/src/avx2/BlendshapePacking_avx2.cpp
@@ -153,13 +153,13 @@ void packBlendshapeOffsets_AVX2(float (*unpacked)[9], uint32_t (*packed)[4], int
         __m256 s7 = _mm256_setzero_ps();
 
         switch (rem) {
-            case 7: s6 = _mm256_loadu_ps(unpacked[i+6]);
-            case 6: s5 = _mm256_loadu_ps(unpacked[i+5]);
-            case 5: s4 = _mm256_loadu_ps(unpacked[i+4]);
-            case 4: s3 = _mm256_loadu_ps(unpacked[i+3]);
-            case 3: s2 = _mm256_loadu_ps(unpacked[i+2]);
-            case 2: s1 = _mm256_loadu_ps(unpacked[i+1]);
-            case 1: s0 = _mm256_loadu_ps(unpacked[i+0]);
+            case 7: s6 = _mm256_loadu_ps(unpacked[i+6]); /* fall-thru */
+            case 6: s5 = _mm256_loadu_ps(unpacked[i+5]); /* fall-thru */
+            case 5: s4 = _mm256_loadu_ps(unpacked[i+4]); /* fall-thru */
+            case 4: s3 = _mm256_loadu_ps(unpacked[i+3]); /* fall-thru */
+            case 3: s2 = _mm256_loadu_ps(unpacked[i+2]); /* fall-thru */
+            case 2: s1 = _mm256_loadu_ps(unpacked[i+1]); /* fall-thru */
+            case 1: s0 = _mm256_loadu_ps(unpacked[i+0]); /* fall-thru */
         }
         
         __m256 t0 = _mm256_unpacklo_ps(s0, s1);
@@ -269,13 +269,13 @@ void packBlendshapeOffsets_AVX2(float (*unpacked)[9], uint32_t (*packed)[4], int
 
         // store pack x 8
         switch (rem) {
-            case 7: _mm_storeu_si128((__m128i*)packed[i+6], _mm256_extractf128_si256(v2, 1));
-            case 6: _mm_storeu_si128((__m128i*)packed[i+5], _mm256_extractf128_si256(v1, 1));
-            case 5: _mm_storeu_si128((__m128i*)packed[i+4], _mm256_extractf128_si256(v0, 1));
-            case 4: _mm_storeu_si128((__m128i*)packed[i+3], _mm256_castsi256_si128(v3));
-            case 3: _mm_storeu_si128((__m128i*)packed[i+2], _mm256_castsi256_si128(v2));
-            case 2: _mm_storeu_si128((__m128i*)packed[i+1], _mm256_castsi256_si128(v1));
-            case 1: _mm_storeu_si128((__m128i*)packed[i+0], _mm256_castsi256_si128(v0));
+            case 7: _mm_storeu_si128((__m128i*)packed[i+6], _mm256_extractf128_si256(v2, 1)); /* fall-thru */
+            case 6: _mm_storeu_si128((__m128i*)packed[i+5], _mm256_extractf128_si256(v1, 1)); /* fall-thru */
+            case 5: _mm_storeu_si128((__m128i*)packed[i+4], _mm256_extractf128_si256(v0, 1)); /* fall-thru */
+            case 4: _mm_storeu_si128((__m128i*)packed[i+3], _mm256_castsi256_si128(v3)); /* fall-thru */
+            case 3: _mm_storeu_si128((__m128i*)packed[i+2], _mm256_castsi256_si128(v2)); /* fall-thru */
+            case 2: _mm_storeu_si128((__m128i*)packed[i+1], _mm256_castsi256_si128(v1)); /* fall-thru */
+            case 1: _mm_storeu_si128((__m128i*)packed[i+0], _mm256_castsi256_si128(v0)); /* fall-thru */
         }
     }
 

--- a/libraries/shared/src/shared/ConicalViewFrustum.cpp
+++ b/libraries/shared/src/shared/ConicalViewFrustum.cpp
@@ -14,6 +14,7 @@
 
 #include "../NumericalConstants.h"
 #include "../ViewFrustum.h"
+#include <glm/gtc/type_ptr.hpp>
 
 void ConicalViewFrustum::set(const ViewFrustum& viewFrustum) {
     // The ConicalViewFrustum has two parts: a central sphere (same as ViewFrustum) and a circular cone that bounds the frustum part.
@@ -131,9 +132,9 @@ int ConicalViewFrustum::serialize(unsigned char* destinationBuffer) const {
 int ConicalViewFrustum::deserialize(const unsigned char* sourceBuffer) {
     const unsigned char* startPosition = sourceBuffer;
 
-    memcpy(&_position, sourceBuffer, sizeof(_position));
+    memcpy(glm::value_ptr(_position), sourceBuffer, sizeof(_position));
     sourceBuffer += sizeof(_position);
-    memcpy(&_direction, sourceBuffer, sizeof(_direction));
+    memcpy(glm::value_ptr(_direction), sourceBuffer, sizeof(_direction));
     sourceBuffer += sizeof(_direction);
     sourceBuffer += unpackFloatAngleFromTwoByte((uint16_t*)sourceBuffer, &_angle);
     sourceBuffer += unpackClipValueFromTwoByte(sourceBuffer, _farClip);

--- a/plugins/KasenAPIExample/src/KasenAPIExample.cpp
+++ b/plugins/KasenAPIExample/src/KasenAPIExample.cpp
@@ -105,7 +105,7 @@ private:
     static QVariantMap zipNonZeroValues(const QStringList& keys, const QVector<float>& values) {
         QVariantMap out;
         for (int i=1; i < values.size(); i++) {
-            if (fabs(values[i]) > 1.0e-6) {
+            if (fabs(values[i]) > 1.0e-6f) {
                 out[keys.value(i)] = values[i];
             }
         }


### PR DESCRIPTION
This fixes a whole bunch of build-time warnings emitted by GCC on Linux

* An incorrect fall-through (so an actual bug)
* Suppress fall-through warnings where a fall-through was intended
* Fix an "X will be initialized after Y" warning (possible bug resulting in a variable not being correctly initialized)
* Fix numerical precision warning
* Fix warnings about signed and unsigned comparison
* Fix a set of Wclass-memaccess warnings.

The last one needs a good looking at, because it touches rendering code. Some of this kind still remain, to be addressed later. I fixed the ones relating to glm:: data types, since GLM is an external library we can't modify. The rest belong to Vircadia code which can be changed.

