### PR TITLE
additional log diagnostics for issue 165

### DIFF
--- a/interface/src/scripting/AudioDevices.cpp
+++ b/interface/src/scripting/AudioDevices.cpp
@@ -385,6 +385,7 @@ void AudioDeviceList::onDevicesChanged(QAudio::Mode mode, const QList<HifiAudioD
         }
     }
 
+    qWarning() << "AudioDeviceList::" << __FUNCTION__ << "(" << mode << ") replacing device list [len=" << rowCount() << "] with new list [len=" << newDevices.length() << "]";
     _devices.swap(newDevices);
     endResetModel();
     
@@ -416,7 +417,8 @@ void AudioInputDeviceList::onPeakValueListChanged(const QList<float>& peakValueL
     assert(_mode == QAudio::AudioInput);
 
     if (peakValueList.length() != rowCount()) {
-        qWarning() << "AudioDeviceList" << __FUNCTION__ << "length mismatch";
+        qWarning() << "AudioDeviceList" << __FUNCTION__ << "length mismatch (received " << peakValueList.length()
+                   << " values when we only have " << rowCount() << " devices)";
     }
 
     for (auto i = 0; i < rowCount(); ++i) {

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -96,6 +96,7 @@ QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode, const QString&
     //get hmd device name prior to locking device mutex. in case of shutdown, this thread will be locked and audio client
     //cannot properly shut down. 
     QString defDeviceName = defaultAudioDeviceName(mode);
+    qWarning() << __FUNCTION__ << "(" << mode << ") default device name: " << defDeviceName;
 
     // NOTE: availableDevices() clobbers the Qt internal device list
     Lock lock(_deviceMutex);
@@ -105,13 +106,14 @@ QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode, const QString&
     QList<HifiAudioDeviceInfo> newDevices;
     for (auto& device : devices) {
         newDevices.push_back(HifiAudioDeviceInfo(device, false, mode));
+        qWarning() << __FUNCTION__ << "(" << mode << ") found audio device named: " << device.deviceName();
         if (device.deviceName() == defDeviceName.trimmed()) {
             defaultDesktopDevice = HifiAudioDeviceInfo(device, true, mode, HifiAudioDeviceInfo::desktop);
         }
     }
 
     if (defaultDesktopDevice.getDevice().isNull()) {
-        qCDebug(audioclient) << __FUNCTION__ << "Default device not found in list:" << defDeviceName
+        qWarning() << __FUNCTION__ << "Default device not found in list:" << defDeviceName
             << "Setting Default to: " << devices.first().deviceName();
         defaultDesktopDevice = HifiAudioDeviceInfo(devices.first(), true, mode, HifiAudioDeviceInfo::desktop);
     }


### PR DESCRIPTION
Adds a few diagnostic warnings in the log to try to help track down "no audio devices" in issue 165