### PR TITLE
Fix Linux default audio device debug messages

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -611,6 +611,14 @@ QString defaultAudioDeviceName(QAudio::Mode mode) {
 #endif
 
 #endif
+
+#ifdef Q_OS_LINUX
+    if ( mode == QAudio::AudioInput ) {
+        deviceName = QAudioDeviceInfo::defaultInputDevice().deviceName();
+    } else {
+        deviceName = QAudioDeviceInfo::defaultOutputDevice().deviceName();
+    }
+#endif
    return deviceName;
 }
 


### PR DESCRIPTION
This fixes the constant stream of:

    [06/07 15:18:15] [DEBUG] [hifi.audioclient] getAvailableDevices Default device not found in list: "" Setting Default to:  "pulse"
    [06/07 15:18:17] [DEBUG] [hifi.audioclient] getAvailableDevices Default device not found in list: "" Setting Default to:  "pulse"
    [06/07 15:18:18] [DEBUG] [hifi.audioclient] getAvailableDevices Default device not found in list: "" Setting Default to:  "pulse"
    [06/07 15:18:20] [DEBUG] [hifi.audioclient] getAvailableDevices Default device not found in list: "" Setting Default to:  "pulse"
    [06/07 15:18:20] [DEBUG] [hifi.audioclient] getAvailableDevices Default device not found in list: "" Setting Default to:  "pulse"


Linux had no default audio implementation, implemented using QAudioDeviceInfo.

Speaking of which, is there some reason why this approach isn't taken on all architectures?

