### PR TITLE
Bug: properly force creating temp domain name if the --get-temp-name

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -263,7 +263,7 @@ DomainServer::DomainServer(int argc, char* argv[]) :
 
     // check for the temporary name parameter
     if (_getTempName) {
-        getTemporaryName();
+        getTemporaryName(true);
     }
 
     // send signal to DomainMetadata when descriptors changed


### PR DESCRIPTION
I found that sometimes the --get-temp-name domain-server parameter did not work. Found that the forcing of temporary domain name creation relied on an unspecified parameter and thus was checking on uninitialized stack memory.
I can't believe a real programming language allows this.
