### PR TITLE
Enable flying in VR by default

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1988,7 +1988,7 @@ void MyAvatar::loadData() {
 
     // Flying preferences must be loaded before calling setFlyingEnabled()
     Setting::Handle<bool> firstRunVal { Settings::firstRun, true };
-    setFlyingHMDPref(firstRunVal.get() ? false : _flyingHMDSetting.get());
+    setFlyingHMDPref(firstRunVal.get() ? true : _flyingHMDSetting.get());
     setMovementReference(firstRunVal.get() ? false : _movementReferenceSetting.get());
     setDriveGear1(firstRunVal.get() ? DEFAULT_GEAR_1 : _driveGear1Setting.get());
     setDriveGear2(firstRunVal.get() ? DEFAULT_GEAR_2 : _driveGear2Setting.get());

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -2702,7 +2702,7 @@ private:
 
     bool _enableFlying { false };
     bool _flyingPrefDesktop { true };
-    bool _flyingPrefHMD { false };
+    bool _flyingPrefHMD { true };
     bool _wasPushing { false };
     bool _isPushing { false };
     bool _isBeingPushed { false };


### PR DESCRIPTION
Flying in VR is now enabled by default in new Interface installations (and if Interface.json settings are deleted): Settings > Controls > Settings > VR Movement > Jumping and flying option is enabled by default.
