### PR TITLE
GHA master merge improvements

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -102,6 +102,11 @@ jobs:
       uses: highfidelity/build-number@v3
       with:
         output_name: RELEASE_NUMBER
+    - name: Report GHA run numbers
+      shell: bash
+      run: |
+        echo "Action run ID (GITHUB_RUN_ID): $GITHUB_RUN_ID"
+        echo "Workflow run ID (GITHUB_RUN_NUMBER): $GITHUB_RUN_NUMBER"
     - name: Configure Build Environment 1
       shell: bash
       id: buildenv1

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macOS-latest]
-        build_type: [full, client]
+        build_type: full
         #os: [windows-latest, macOS-latest, ubuntu-latest]
         # exclude:
         #   - os: ubuntu-latest

--- a/libraries/auto-updater/src/AutoUpdater.cpp
+++ b/libraries/auto-updater/src/AutoUpdater.cpp
@@ -40,6 +40,10 @@ const QUrl BUILDS_XML_URL("https://highfidelity.com/builds.xml");
 const QUrl MASTER_BUILDS_XML_URL("https://highfidelity.com/dev-builds.xml");
 
 void AutoUpdater::getLatestVersionData() {
+
+    // FIXME: Implement Vircadia version of latest version checking.
+    /*
+
     QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
 
     QUrl buildsURL;
@@ -56,6 +60,8 @@ void AutoUpdater::getLatestVersionData() {
     latestVersionRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
     QNetworkReply* reply = networkAccessManager.get(latestVersionRequest);
     connect(reply, &QNetworkReply::finished, this, &AutoUpdater::parseLatestVersionData);
+
+    */
 }
 
 void AutoUpdater::parseLatestVersionData() {


### PR DESCRIPTION
- Don't build Interface-only builds.
- Disable High Fidelity auto updater check. (See https://github.com/kasenvr/project-athena/issues/396 .)
- Report native GHA build (run) numbers as possible alternative to using https://github.com/highfidelity/build-number for generating build numbers.