### PR TITLE
Include <stdexcept> for building on Windows10 with Visual Studio 2019

### DIFF
--- a/libraries/ktx/src/khronos/KHR.h
+++ b/libraries/ktx/src/khronos/KHR.h
@@ -11,6 +11,7 @@
 #define khronos_khr_hpp
 
 #include <unordered_map>
+#include <stdexcept>
 
 namespace khronos {
 

--- a/libraries/shared/src/shared/Storage.h
+++ b/libraries/shared/src/shared/Storage.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <memory>
 #include <functional>
+#include <stdexcept>
 
 #include <QtCore/QFile>
 #include <QtCore/QString>


### PR DESCRIPTION
Found that building project-athena on Windows10 with Visual Studio 2019 using the latest CMake integrated in VS required the inclusion of these 'include' files. These 'includes' do not seem to be needed on Linux so I presume the problem is that the include dependency tree is a little different on Windows10.