### PR TITLE
Disable crash logger by default

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -620,7 +620,7 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(networkMenu,
         MenuOption::DisableCrashLogger,
         0,
-        false,
+        true,
         &UserActivityLogger::getInstance(),
         SLOT(crashMonitorDisable(bool)));
     addActionToQMenuAndActionHash(networkMenu, MenuOption::ShowDSConnectTable, 0,

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -86,7 +86,7 @@ namespace MenuOption {
     const QString DeleteAvatarEntitiesBookmark = "Delete Avatar Entities Bookmark";
     const QString DeleteBookmark = "Delete Bookmark...";
     const QString DisableActivityLogger = "Disable Activity Logger";
-    const QString DisableCrashLogger = "Disable Crash Logger";
+    const QString DisableCrashLogger = "Disable Crash Reporter";
     const QString DisableEyelidAdjustment = "Disable Eyelid Adjustment";
     const QString DisableLightEntities = "Disable Light Entities";
     const QString DisplayCrashOptions = "Display Crash Options";

--- a/libraries/networking/src/UserActivityLogger.h
+++ b/libraries/networking/src/UserActivityLogger.h
@@ -59,7 +59,7 @@ private slots:
 private:
     UserActivityLogger();
     Setting::Handle<bool> _disabled { "UserActivityLoggerDisabled", true };
-    Setting::Handle<bool> _crashMonitorDisabled { "CrashMonitorDisabled", false };
+    Setting::Handle<bool> _crashMonitorDisabled { "CrashMonitorDisabled", true };
 
     QElapsedTimer _timer;
 };

--- a/libraries/networking/src/UserActivityLogger.h
+++ b/libraries/networking/src/UserActivityLogger.h
@@ -59,7 +59,7 @@ private slots:
 private:
     UserActivityLogger();
     Setting::Handle<bool> _disabled { "UserActivityLoggerDisabled", true };
-    Setting::Handle<bool> _crashMonitorDisabled { "CrashMonitorDisabled", true };
+    Setting::Handle<bool> _crashMonitorDisabled { "CrashMonitorDisabled2", true };
 
     QElapsedTimer _timer;
 };


### PR DESCRIPTION
The crash logger could end up sending some private data, so just in case it's now off by default.

This change won't affect existing installations, only the default is modified.

