### PR TITLE
Fix models not scaling correctly when loading due to timeout.

### DIFF
--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -621,6 +621,10 @@ var toolBar = (function () {
                         dimensions: naturalDimensions
                     })
                     dimensionsCheckCallback();
+                    // We want to update the selection manager again since the script has moved on without us.
+                    selectionManager.clearSelections(this);
+                    entityListTool.sendUpdate();
+                    selectionManager.setSelections([entityID], this);
                     return;
                 }
                 Script.setTimeout(entityIsLoadedCheck, LOADED_CHECK_INTERVAL);

--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -603,15 +603,19 @@ var toolBar = (function () {
                 Script.setTimeout(dimensionsCheckFunction, DIMENSIONS_CHECK_INTERVAL);
             }
             // Make sure the model entity is loaded before we try to figure out
-            // its dimensions.
-            var MAX_LOADED_CHECKS = 10;
+            // its dimensions. We need to give ample time to load the entity.
+            var MAX_LOADED_CHECKS = 100; // 100 * 100ms = 10 seconds.
             var LOADED_CHECK_INTERVAL = 100;
             var isLoadedCheckCount = 0;
             var entityIsLoadedCheck = function() {
                 isLoadedCheckCount++;
                 if (isLoadedCheckCount === MAX_LOADED_CHECKS || Entities.isLoaded(entityID)) {
                     var naturalDimensions = Entities.getEntityProperties(entityID, "naturalDimensions").naturalDimensions;
-
+                    
+                    if (isLoadedCheckCount === MAX_LOADED_CHECKS) {
+                        console.log("Model entity failed to load in time: " + (MAX_LOADED_CHECKS * LOADED_CHECK_INTERVAL) + " ... setting dimensions to: " + JSON.stringify(naturalDimensions))
+                    }
+                    
                     Entities.editEntity(entityID, {
                         visible: true,
                         dimensions: naturalDimensions


### PR DESCRIPTION
**Issue:** Loading a model through the Create App would cause its dimensions to be set to 1m^3. This would happen because the app would wait for the model to load before checking its dimensions and setting them, however the app had a strict timeout of 1s. So, if the model is in your cache then it would work. If the model was cachebusted or just in general new, it would not work as the loading would *likely* take more than 1 second.

**Solution:** I raised the timeout to 10 seconds and also put a message if the model gets wrongly sized due to running out of time that way the user will at least have some indication of what happened, and why, and so will developers.

**Test Plan:** Load a model entity into the world that is not cached, cachebust one if you would like. If it comes in under 10 seconds, it should be set to the correct dimensions. If it takes more than 10 seconds, it should be 1m^3.