### PR TITLE
Fix reloading content in serverless domain

### DIFF
--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -211,6 +211,7 @@ void DomainHandler::setURLAndID(QUrl domainURL, QUuid domainID) {
     // if it's in the error state, reset and try again.
     if (_domainURL != domainURL 
         || (_sockAddr.getPort() != domainPort && domainURL.scheme() == URL_SCHEME_HIFI)
+        || isServerless() // For reloading content in serverless domain.
         || _isInErrorState) {
         // re-set the domain info so that auth information is reloaded
         hardReset("Changing domain URL");


### PR DESCRIPTION
- Reloading content in serverless domain (e.g., file:///~/serverless/tutorial.json) should now work. 
- Reloading content in normal domain should still work.
