### PR TITLE
TEST PR: redirect metaverse-server to project-apollo test server

### DIFF
--- a/domain-server/resources/web/js/shared.js
+++ b/domain-server/resources/web/js/shared.js
@@ -52,6 +52,7 @@ var URLs = {
   // STABLE METAVERSE_URL: https://metaverse.highfidelity.com
   // STAGING METAVERSE_URL: https://staging.highfidelity.com
   METAVERSE_URL: 'https://metaverse.highfidelity.com',
+  CDN_URL: 'https://cdn.highfidelity.com',
   PLACE_URL: 'https://hifi.place',
 };
 

--- a/domain-server/resources/web/js/shared.js
+++ b/domain-server/resources/web/js/shared.js
@@ -51,7 +51,7 @@ $.extend(Settings, {
 var URLs = {
   // STABLE METAVERSE_URL: https://metaverse.highfidelity.com
   // STAGING METAVERSE_URL: https://staging.highfidelity.com
-  METAVERSE_URL: 'http://metaverse.bluestuff.org',
+  METAVERSE_URL: 'http://metaverse.bluestuff.org:9400',
   CDN_URL: 'https://cdn.highfidelity.com',
   PLACE_URL: 'https://hifi.place',
 };

--- a/domain-server/resources/web/js/shared.js
+++ b/domain-server/resources/web/js/shared.js
@@ -51,7 +51,7 @@ $.extend(Settings, {
 var URLs = {
   // STABLE METAVERSE_URL: https://metaverse.highfidelity.com
   // STAGING METAVERSE_URL: https://staging.highfidelity.com
-  METAVERSE_URL: 'https://metaverse.highfidelity.com',
+  METAVERSE_URL: 'http://metaverse.bluestuff.org',
   CDN_URL: 'https://cdn.highfidelity.com',
   PLACE_URL: 'https://hifi.place',
 };

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -70,13 +70,7 @@ const QString DomainServer::REPLACEMENT_FILE_EXTENSION = ".replace";
 
 int const DomainServer::EXIT_CODE_REBOOT = 234923;
 
-#if USE_STABLE_GLOBAL_SERVICES
-const QString ICE_SERVER_DEFAULT_HOSTNAME = "ice.highfidelity.com";
-#else
-const QString ICE_SERVER_DEFAULT_HOSTNAME = "dev-ice.highfidelity.com";
-#endif
-
-QString DomainServer::_iceServerAddr { ICE_SERVER_DEFAULT_HOSTNAME };
+QString DomainServer::_iceServerAddr { NetworkingConstants::ICE_SERVER_DEFAULT_HOSTNAME };
 int DomainServer::_iceServerPort { ICE_SERVER_DEFAULT_PORT };
 bool DomainServer::_overrideDomainID { false };
 QUuid DomainServer::_overridingDomainID;

--- a/ice-server/src/IceServer.cpp
+++ b/ice-server/src/IceServer.cpp
@@ -252,7 +252,7 @@ void IceServer::publicKeyReplyFinished(QNetworkReply* reply) {
                 // convert the downloaded public key to an RSA struct, if possible
                 const unsigned char* publicKeyData = reinterpret_cast<const unsigned char*>(apiPublicKey.constData());
 
-                RSA* rsaPublicKey = d2i_RSA_PUBKEY(NULL, &publicKeyData, apiPublicKey.size());
+                RSA* rsaPublicKey = d2i_RSAPublicKey(NULL, &publicKeyData, apiPublicKey.size());
 
                 if (rsaPublicKey) {
                     _domainPublicKeys[domainID] = { rsaPublicKey, RSA_free };

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -347,7 +347,6 @@ static const QString STANDARD_TO_ACTION_MAPPING_NAME = "Standard to Action";
 static const QString NO_MOVEMENT_MAPPING_NAME = "Standard to Action (No Movement)";
 static const QString NO_MOVEMENT_MAPPING_JSON = PathUtils::resourcesPath() + "/controllers/standard_nomovement.json";
 
-static const QString MARKETPLACE_CDN_HOSTNAME = "mpassets.highfidelity.com";
 static const int INTERVAL_TO_CHECK_HMD_WORN_STATUS = 500; // milliseconds
 static const QString DESKTOP_DISPLAY_PLUGIN_NAME = "Desktop";
 static const QString ACTIVE_DISPLAY_PLUGIN_SETTING_NAME = "activeDisplayPlugin";
@@ -7620,7 +7619,7 @@ bool Application::askToLoadScript(const QString& scriptFilenameOrURL) {
 
     QUrl scriptURL { scriptFilenameOrURL };
 
-    if (scriptURL.host().endsWith(MARKETPLACE_CDN_HOSTNAME)) {
+    if (scriptURL.host().endsWith(NetworkingConstants::MARKETPLACE_CDN_HOSTNAME)) {
         int startIndex = shortName.lastIndexOf('/') + 1;
         int endIndex = shortName.lastIndexOf('?');
         shortName = shortName.mid(startIndex, endIndex - startIndex);
@@ -7743,7 +7742,7 @@ bool Application::askToReplaceDomainContent(const QString& url) {
     const int MAX_CHARACTERS_PER_LINE = 90;
     if (DependencyManager::get<NodeList>()->getThisNodeCanReplaceContent()) {
         QUrl originURL { url };
-        if (originURL.host().endsWith(MARKETPLACE_CDN_HOSTNAME)) {
+        if (originURL.host().endsWith(NetworkingConstants::MARKETPLACE_CDN_HOSTNAME)) {
             // Create a confirmation dialog when this call is made
             static const QString infoText = simpleWordWrap("Your domain's content will be replaced with a new content set. "
                 "If you want to save what you have now, create a backup before proceeding. For more information about backing up "

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -799,19 +799,19 @@ Menu::Menu() {
     // Help > Vircadia Docs
     action = addActionToQMenuAndActionHash(helpMenu, "Online Documentation");
     connect(action, &QAction::triggered, qApp, [] {
-        QDesktopServices::openUrl(QUrl("https://docs.vircadia.dev/"));
+        QDesktopServices::openUrl(NetworkingConstants::HELP_DOCS_URL);
     });
 
     // Help > Vircadia Forum
     /* action = addActionToQMenuAndActionHash(helpMenu, "Online Forums");
     connect(action, &QAction::triggered, qApp, [] {
-        QDesktopServices::openUrl(QUrl("https://forums.highfidelity.com/"));
+        QDesktopServices::openUrl(NetworkingConstants::HELP_FORUM_URL));
     }); */
 
     // Help > Scripting Reference
     action = addActionToQMenuAndActionHash(helpMenu, "Online Script Reference");
     connect(action, &QAction::triggered, qApp, [] {
-        QDesktopServices::openUrl(QUrl("https://apidocs.vircadia.dev/"));
+        QDesktopServices::openUrl(NetworkingConstants::HELP_SCRIPTING_REFERENCE_URL);
     });
 
     addActionToQMenuAndActionHash(helpMenu, "Controls Reference", 0, qApp, SLOT(showHelp()));
@@ -821,13 +821,13 @@ Menu::Menu() {
     // Help > Release Notes
     action = addActionToQMenuAndActionHash(helpMenu, "Release Notes");
     connect(action, &QAction::triggered, qApp, [] {
-        QDesktopServices::openUrl(QUrl("https://docs.vircadia.dev/release-notes.html"));
+        QDesktopServices::openUrl(NetworkingConstants::HELP_RELEASE_NOTES_URL);
     });
 
     // Help > Report a Bug!
     action = addActionToQMenuAndActionHash(helpMenu, "Report a Bug!");
     connect(action, &QAction::triggered, qApp, [] {
-        QDesktopServices::openUrl(QUrl("https://github.com/kasenvr/project-athena/issues"));
+        QDesktopServices::openUrl(NetworkingConstants::HELP_BUG_REPORT_URL);
     });
 }
 

--- a/libraries/auto-updater/src/AutoUpdater.cpp
+++ b/libraries/auto-updater/src/AutoUpdater.cpp
@@ -16,6 +16,7 @@
 #include <ApplicationVersion.h>
 #include <BuildInfo.h>
 #include <NetworkAccessManager.h>
+#include <NetworkingConstants.h>
 #include <SharedUtil.h>
 
 AutoUpdater::AutoUpdater() :
@@ -36,18 +37,15 @@ void AutoUpdater::checkForUpdate() {
     this->getLatestVersionData();
 }
 
-const QUrl BUILDS_XML_URL("https://highfidelity.com/builds.xml");
-const QUrl MASTER_BUILDS_XML_URL("https://highfidelity.com/dev-builds.xml");
-
 void AutoUpdater::getLatestVersionData() {
     QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
 
     QUrl buildsURL;
 
     if (BuildInfo::BUILD_TYPE == BuildInfo::BuildType::Stable) {
-        buildsURL = BUILDS_XML_URL;
+        buildsURL = NetworkingConstants::BUILDS_XML_URL;
     } else if (BuildInfo::BUILD_TYPE == BuildInfo::BuildType::Master) {
-        buildsURL = MASTER_BUILDS_XML_URL;
+        buildsURL = NetworkingConstants::MASTER_BUILDS_XML_URL;
     }
     
     QNetworkRequest latestVersionRequest(buildsURL);

--- a/libraries/networking/src/NetworkingConstants.h
+++ b/libraries/networking/src/NetworkingConstants.h
@@ -27,6 +27,28 @@ namespace NetworkingConstants {
 
     const QUrl METAVERSE_SERVER_URL_STABLE { "https://metaverse.highfidelity.com" };
     const QUrl METAVERSE_SERVER_URL_STAGING { "https://staging-metaverse.vircadia.com" };
+
+    // Web Engine requests to this parent domain have an account authorization header added
+    const QString AUTH_HOSTNAME_BASE = "highfidelity.com";
+
+    const QUrl BUILDS_XML_URL("https://highfidelity.com/builds.xml");
+    const QUrl MASTER_BUILDS_XML_URL("https://highfidelity.com/dev-builds.xml");
+
+
+#if USE_STABLE_GLOBAL_SERVICES
+    const QString ICE_SERVER_DEFAULT_HOSTNAME = "ice.highfidelity.com";
+#else
+    const QString ICE_SERVER_DEFAULT_HOSTNAME = "dev-ice.highfidelity.com";
+#endif
+
+    const QString MARKETPLACE_CDN_HOSTNAME = "mpassets.highfidelity.com";
+
+    const QUrl HELP_DOCS_URL { "https://docs.vircadia.dev" };
+    const QUrl HELP_FORUM_URL { "https://forums.vircadia.dev" };
+    const QUrl HELP_SCRIPTING_REFERENCE_URL{ "https://apidocs.vircadia.dev/" };
+    const QUrl HELP_RELEASE_NOTES_URL{ "https://docs.vircadia.dev/release-notes.html" };
+    const QUrl HELP_BUG_REPORT_URL{ "https://github.com/kasenvr/project-athena/issues" };
+
 }
 
 const QString HIFI_URL_SCHEME_ABOUT = "about";

--- a/libraries/networking/src/NetworkingConstants.h
+++ b/libraries/networking/src/NetworkingConstants.h
@@ -25,11 +25,11 @@ namespace NetworkingConstants {
     // if you manually generate a personal access token for the domains scope
     // at https://staging.highfidelity.com/user/tokens/new?for_domain_server=true
 
-    const QUrl METAVERSE_SERVER_URL_STABLE { "http://metaverse.bluestuff.org" };
-    const QUrl METAVERSE_SERVER_URL_STAGING { "http://metaverse.bluestuff.org" };
+    const QUrl METAVERSE_SERVER_URL_STABLE { "http://metaverse.bluestuff.org:9400" };
+    const QUrl METAVERSE_SERVER_URL_STAGING { "http://metaverse.bluestuff.org:9400" };
 
     // Web Engine requests to this parent domain have an account authorization header added
-    const QString AUTH_HOSTNAME_BASE = "metaverse.bluestuff.org";
+    const QString AUTH_HOSTNAME_BASE = "metaverse.bluestuff.org:9400";
 
     const QUrl BUILDS_XML_URL("https://highfidelity.com/builds.xml");
     const QUrl MASTER_BUILDS_XML_URL("https://highfidelity.com/dev-builds.xml");

--- a/libraries/networking/src/NetworkingConstants.h
+++ b/libraries/networking/src/NetworkingConstants.h
@@ -25,20 +25,20 @@ namespace NetworkingConstants {
     // if you manually generate a personal access token for the domains scope
     // at https://staging.highfidelity.com/user/tokens/new?for_domain_server=true
 
-    const QUrl METAVERSE_SERVER_URL_STABLE { "https://metaverse.highfidelity.com" };
-    const QUrl METAVERSE_SERVER_URL_STAGING { "https://staging-metaverse.vircadia.com" };
+    const QUrl METAVERSE_SERVER_URL_STABLE { "https://metaverse.bluestuff.org" };
+    const QUrl METAVERSE_SERVER_URL_STAGING { "https://staging-metaverse.bluestuff.org" };
 
     // Web Engine requests to this parent domain have an account authorization header added
-    const QString AUTH_HOSTNAME_BASE = "highfidelity.com";
+    const QString AUTH_HOSTNAME_BASE = "metaverse.bluestuff.org";
 
     const QUrl BUILDS_XML_URL("https://highfidelity.com/builds.xml");
     const QUrl MASTER_BUILDS_XML_URL("https://highfidelity.com/dev-builds.xml");
 
 
 #if USE_STABLE_GLOBAL_SERVICES
-    const QString ICE_SERVER_DEFAULT_HOSTNAME = "ice.highfidelity.com";
+    const QString ICE_SERVER_DEFAULT_HOSTNAME = "ice.bluestuff.org";
 #else
-    const QString ICE_SERVER_DEFAULT_HOSTNAME = "dev-ice.highfidelity.com";
+    const QString ICE_SERVER_DEFAULT_HOSTNAME = "dev-ice.bluestuff.org";
 #endif
 
     const QString MARKETPLACE_CDN_HOSTNAME = "mpassets.highfidelity.com";

--- a/libraries/networking/src/NetworkingConstants.h
+++ b/libraries/networking/src/NetworkingConstants.h
@@ -25,8 +25,8 @@ namespace NetworkingConstants {
     // if you manually generate a personal access token for the domains scope
     // at https://staging.highfidelity.com/user/tokens/new?for_domain_server=true
 
-    const QUrl METAVERSE_SERVER_URL_STABLE { "https://metaverse.bluestuff.org" };
-    const QUrl METAVERSE_SERVER_URL_STAGING { "https://staging-metaverse.bluestuff.org" };
+    const QUrl METAVERSE_SERVER_URL_STABLE { "http://metaverse.bluestuff.org" };
+    const QUrl METAVERSE_SERVER_URL_STAGING { "http://metaverse.bluestuff.org" };
 
     // Web Engine requests to this parent domain have an account authorization header added
     const QString AUTH_HOSTNAME_BASE = "metaverse.bluestuff.org";
@@ -38,7 +38,7 @@ namespace NetworkingConstants {
 #if USE_STABLE_GLOBAL_SERVICES
     const QString ICE_SERVER_DEFAULT_HOSTNAME = "ice.bluestuff.org";
 #else
-    const QString ICE_SERVER_DEFAULT_HOSTNAME = "dev-ice.bluestuff.org";
+    const QString ICE_SERVER_DEFAULT_HOSTNAME = "ice.bluestuff.org";
 #endif
 
     const QString MARKETPLACE_CDN_HOSTNAME = "mpassets.highfidelity.com";

--- a/libraries/ui/src/ui/types/RequestFilters.cpp
+++ b/libraries/ui/src/ui/types/RequestFilters.cpp
@@ -29,7 +29,7 @@ namespace {
         auto metaverseServerURL = MetaverseAPI::getCurrentMetaverseServerURL();
         static const QStringList HF_HOSTS = {
             "highfidelity.com", "highfidelity.io",
-            metaverseServerURL.toString(), "metaverse.highfidelity.io"
+            metaverseServerURL.toString(),
         };
         const auto& scheme = url.scheme();
         const auto& host = url.host();


### PR DESCRIPTION
This PR changes the coded metaverse server to "metaverse.bluestuff.org" and the ice-server to "ice.bluestuff.org" which are the test servers for the project-apollo metaverse server development.

This PR should not be merged. This exists only so the build system will build executables for testing.