### PR TITLE
Add Help > Tutorial menu item

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3858,6 +3858,11 @@ void Application::showHelp() {
     //InfoView::show(INFO_HELP_PATH, false, queryString.toString());
 }
 
+void Application::gotoTutorial() {
+    const QString TUTORIAL_ADDRESS = "file:///~/serverless/tutorial.json";
+    DependencyManager::get<AddressManager>()->handleLookupString(TUTORIAL_ADDRESS);
+}
+
 void Application::resizeEvent(QResizeEvent* event) {
     resizeGL();
 }

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -427,6 +427,7 @@ public slots:
 #endif
 
     static void showHelp();
+    static void gotoTutorial();
 
     void cycleCamera();
     void cameraModeChanged();

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -816,6 +816,8 @@ Menu::Menu() {
 
     addActionToQMenuAndActionHash(helpMenu, "Controls Reference", 0, qApp, SLOT(showHelp()));
 
+    addActionToQMenuAndActionHash(helpMenu, "Tutorial", 0, qApp, SLOT(gotoTutorial()));
+
     helpMenu->addSeparator();
 
     // Help > Release Notes

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -249,8 +249,9 @@ public slots:
      * Takes you to a specified metaverse address.
      * @function location.handleLookupString
      * @param {string} address - The address to go to: a <code>"hifi://"</code> address, an IP address (e.g., 
-     *     <code>"127.0.0.1"</code> or <code>"localhost"</code>), a domain name, a named path on a domain (starts with 
-     *     <code>"/"</code>), a position or position and orientation, or a user (starts with <code>"@"</code>).
+     *     <code>"127.0.0.1"</code> or <code>"localhost"</code>), a <code>file:///</code> address, a domain name, a named path 
+     *     on a domain (starts with <code>"/"</code>), a position or position and orientation, or a user (starts with 
+     *     <code>"@"</code>).
      * @param {boolean} [fromSuggestions=false] - Set to <code>true</code> if the address is obtained from the "Goto" dialog.
      *     Helps ensure that user's location history is correctly maintained.
      */


### PR DESCRIPTION
This so that the serverless tutorial can be readily revisited.
Also fixed up JSDoc for AddressManager.handleLookupString().