### PR TITLE
Little "Audio" settings UI improvements

### DIFF
--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -572,7 +572,7 @@ Rectangle {
         ListView {
             id: inputView;
             width: rightMostInputLevelPos;
-            anchors.top: loopbackAudio.bottom;
+            anchors.top: (loopbackAudio.visible === 1) ? loopbackAudio.bottom : inputDeviceHeader.bottom;
             anchors.topMargin: 10;
             x: margins.paddings
             interactive: false;

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -680,7 +680,7 @@ Rectangle {
         AudioControls.PlaySampleSound {
             id: playSampleSound
             x: margins.paddings
-            anchors.top: systemInjectorGainContainer.bottom;
+            anchors.top: outputView.bottom;
             anchors.topMargin: 10;
         }
     }

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -682,7 +682,12 @@ Rectangle {
             x: margins.paddings
             anchors.top: outputView.bottom;
             anchors.topMargin: 10;
-            bottomMargin: 5;
+        }
+        
+        // Spacer item 
+        Item {
+            anchors.top: playSampleSound.bottom;
+            anchors.topMargin: 5;
         }
     }
 

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -332,7 +332,7 @@ Rectangle {
         Item {
             id: avatarGainContainer
             x: margins.paddings;
-            anchors.top: outputView.bottom;
+            anchors.top: pttTextContainer.bottom;
             anchors.topMargin: 10;
             width: parent.width - margins.paddings*2
             height: avatarGainSliderTextMetrics.height
@@ -515,7 +515,7 @@ Rectangle {
 
         Separator {
             id: secondSeparator;
-            anchors.top: pttTextContainer.visible ? pttTextContainer.bottom : switchesContainer.bottom;
+            anchors.top: systemInjectorGainContainer.visible ? systemInjectorGainContainer.bottom : switchesContainer.bottom;
             anchors.topMargin: 10;
         }
 

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -558,6 +558,16 @@ Rectangle {
             anchors { left: parent.left; leftMargin: margins.paddings }
         }
         
+        AudioControls.InputPeak {
+                    id: inputLevel
+                    anchors.right: parent.right
+                    peak: model.peak;
+                    anchors.verticalCenter: parent.verticalCenter
+                    visible: ((bar.currentIndex === 1 && isVR) ||
+                             (bar.currentIndex === 0 && !isVR)) &&
+                             AudioScriptingInterface.devices.input.peakValuesAvailable;
+        }
+        
         ListView {
             id: inputView;
             width: rightMostInputLevelPos;
@@ -594,22 +604,13 @@ Rectangle {
                             AudioScriptingInterface.setInputDevice(info, bar.currentIndex === 1);
                         }
                     }
-                }
-                AudioControls.InputPeak {
-                    id: inputLevel
-                    anchors.right: parent.right
-                    peak: model.peak;
-                    anchors.verticalCenter: parent.verticalCenter
-                    visible: ((bar.currentIndex === 1 && isVR) ||
-                             (bar.currentIndex === 0 && !isVR)) &&
-                             AudioScriptingInterface.devices.input.peakValuesAvailable;
-                }
+                }  
             }
         }
 
         Separator {
             id: thirdSeparator;
-            anchors.top: loopbackAudio.visible ? loopbackAudio.bottom : inputView.bottom;
+            anchors.top: inputView.visible ? inputView.bottom : outputDeviceHeader.bottom;
             anchors.topMargin: 10;
         }
 

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -682,6 +682,7 @@ Rectangle {
             x: margins.paddings
             anchors.top: outputView.bottom;
             anchors.topMargin: 10;
+            bottomMargin: 5;
         }
     }
 

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -325,7 +325,7 @@ Rectangle {
                 size: 16;
 
                 text: (bar.currentIndex === 0) ? qsTr("Press and hold the button \"T\" to talk.") :
-                                qsTr("Press and hold grip triggers on both of your controllers to talk.");
+                                qsTr("Press and hold triggers on both of your controllers to talk.");
             }
         }
         

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -326,10 +326,10 @@ Rectangle {
                 size: 16;
 
                 text: (bar.currentIndex === 0) ? qsTr("Press and hold the button \"T\" to talk.") :
-                                qsTr("Press and hold triggers on both of your controllers to talk.");
+                                qsTr("Press and hold grip triggers on your controllers to talk.");
             }
         }
-        
+
         Item {
             id: avatarGainContainer
             x: margins.paddings;
@@ -546,29 +546,28 @@ Rectangle {
                 color: hifi.colors.white;
                 text: qsTr("Choose input device");
             }
-        }
-        
-        AudioControls.LoopbackAudio {
-            id: loopbackAudio
-            x: margins.paddings
-            anchors.top: inputDeviceHeader.bottom;
-            anchors.topMargin: 10;
+            AudioControls.LoopbackAudio {
+                id: loopbackAudio
+                x: margins.paddings
+                anchors.top: inputDeviceHeader.bottom;
+                anchors.topMargin: 10;
 
-            visible: (bar.currentIndex === 1 && isVR) ||
-                (bar.currentIndex === 0 && !isVR);
-            anchors { left: parent.left; leftMargin: margins.paddings }
+                visible: (bar.currentIndex === 1 && isVR) ||
+                    (bar.currentIndex === 0 && !isVR);
+                anchors { left: parent.left; leftMargin: margins.paddings }
+            }
+
+            AudioControls.InputPeak {
+                id: inputLevel
+                anchors.right: parent.right
+                peak: model.peak;
+                anchors.verticalCenter: parent.verticalCenter
+                visible: ((bar.currentIndex === 1 && isVR) ||
+                    (bar.currentIndex === 0 && !isVR)) &&
+                    AudioScriptingInterface.devices.input.peakValuesAvailable;
+            }
         }
-        
-        AudioControls.InputPeak {
-                    id: inputLevel
-                    anchors.right: parent.right
-                    peak: model.peak;
-                    anchors.verticalCenter: parent.verticalCenter
-                    visible: ((bar.currentIndex === 1 && isVR) ||
-                             (bar.currentIndex === 0 && !isVR)) &&
-                             AudioScriptingInterface.devices.input.peakValuesAvailable;
-        }
-        
+
         ListView {
             id: inputView;
             width: rightMostInputLevelPos;
@@ -577,14 +576,14 @@ Rectangle {
             x: margins.paddings
             interactive: false;
             height: contentHeight;
-            
+
             clip: true;
             model: AudioScriptingInterface.devices.input;
             delegate: Item {
                 width: rightMostInputLevelPos - margins.paddings*2
-                height: ((type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1)) ?  
+                height: ((type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1)) ?
                         (margins.sizeCheckBox > checkBoxInput.implicitHeight ? margins.sizeCheckBox + 4 : checkBoxInput.implicitHeight + 4) : 0
-                visible: (type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1) 
+                visible: (type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1)
                 AudioControls.CheckBox {
                     id: checkBoxInput
                     anchors.left: parent.left
@@ -605,7 +604,7 @@ Rectangle {
                             AudioScriptingInterface.setInputDevice(info, bar.currentIndex === 1);
                         }
                     }
-                }  
+                }
             }
         }
 
@@ -642,15 +641,15 @@ Rectangle {
                 color: hifi.colors.white;
                 text: qsTr("Choose output device");
             }
+
+            AudioControls.PlaySampleSound {
+                id: playSampleSound
+                x: margins.paddings
+                anchors.top: outputDeviceHeader.bottom;
+                anchors.topMargin: 10;
+            }
         }
-        
-        AudioControls.PlaySampleSound {
-            id: playSampleSound
-            x: margins.paddings
-            anchors.top: outputDeviceHeader.bottom;
-            anchors.topMargin: 10;
-        }
-        
+
         ListView {
             id: outputView
             width: parent.width - margins.paddings*2
@@ -663,9 +662,9 @@ Rectangle {
             model: AudioScriptingInterface.devices.output;
             delegate: Item {
                 width: rightMostInputLevelPos
-                height: ((type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1)) ? 
+                height: ((type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1)) ?
                         (margins.sizeCheckBox > checkBoxOutput.implicitHeight ? margins.sizeCheckBox + 4 : checkBoxOutput.implicitHeight + 4) : 0
-                visible: (type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1) 
+                visible: (type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1)
 
                 AudioControls.CheckBox {
                     id: checkBoxOutput
@@ -685,8 +684,8 @@ Rectangle {
                 }
             }
         }
-        
-        // Spacer item 
+
+        // Spacer item
         Item {
             anchors.top: outputView.bottom;
             anchors.topMargin: 10;

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -516,7 +516,7 @@ Rectangle {
 
         Separator {
             id: secondSeparator;
-            anchors.top: systemInjectorGainContainer.visible ? systemInjectorGainContainer.bottom : switchesContainer.bottom;
+            anchors.top: systemInjectorGainContainer.bottom;
             anchors.topMargin: 10;
         }
 
@@ -611,7 +611,7 @@ Rectangle {
 
         Separator {
             id: thirdSeparator;
-            anchors.top: inputView.visible ? inputView.bottom : outputDeviceHeader.bottom;
+            anchors.top: inputView.bottom;
             anchors.topMargin: 10;
         }
 

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -546,11 +546,22 @@ Rectangle {
                 text: qsTr("Choose input device");
             }
         }
+        
+        AudioControls.LoopbackAudio {
+            id: loopbackAudio
+            x: margins.paddings
+            anchors.top: inputDeviceHeader.bottom;
+            anchors.topMargin: 10;
 
+            visible: (bar.currentIndex === 1 && isVR) ||
+                (bar.currentIndex === 0 && !isVR);
+            anchors { left: parent.left; leftMargin: margins.paddings }
+        }
+        
         ListView {
             id: inputView;
             width: rightMostInputLevelPos;
-            anchors.top: inputDeviceHeader.bottom;
+            anchors.top: loopbackAudio.bottom;
             anchors.topMargin: 10;
             x: margins.paddings
             interactive: false;
@@ -596,17 +607,6 @@ Rectangle {
             }
         }
 
-        AudioControls.LoopbackAudio {
-            id: loopbackAudio
-            x: margins.paddings
-            anchors.top: inputView.bottom;
-            anchors.topMargin: 10;
-
-            visible: (bar.currentIndex === 1 && isVR) ||
-                (bar.currentIndex === 0 && !isVR);
-            anchors { left: parent.left; leftMargin: margins.paddings }
-        }
-
         Separator {
             id: thirdSeparator;
             anchors.top: loopbackAudio.visible ? loopbackAudio.bottom : inputView.bottom;
@@ -641,14 +641,21 @@ Rectangle {
                 text: qsTr("Choose output device");
             }
         }
-
+        
+        AudioControls.PlaySampleSound {
+            id: playSampleSound
+            x: margins.paddings
+            anchors.top: outputDeviceHeader.bottom;
+            anchors.topMargin: 10;
+        }
+        
         ListView {
             id: outputView
             width: parent.width - margins.paddings*2
             x: margins.paddings;
             interactive: false;
             height: contentHeight;
-            anchors.top: outputDeviceHeader.bottom;
+            anchors.top: playSampleSound.bottom;
             anchors.topMargin: 10;
             clip: true;
             model: AudioScriptingInterface.devices.output;
@@ -676,18 +683,11 @@ Rectangle {
                 }
             }
         }
-
-        AudioControls.PlaySampleSound {
-            id: playSampleSound
-            x: margins.paddings
-            anchors.top: outputView.bottom;
-            anchors.topMargin: 10;
-        }
         
         // Spacer item 
         Item {
-            anchors.top: playSampleSound.bottom;
-            anchors.topMargin: 5;
+            anchors.top: outputView.bottom;
+            anchors.topMargin: 10;
         }
     }
 

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -6,6 +6,7 @@
 //
 //  Created by Vlad Stelmahovsky on 03/22/2017
 //  Copyright 2017 High Fidelity, Inc.
+//  Copyright 2020 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -326,7 +326,7 @@ Rectangle {
                 size: 16;
 
                 text: (bar.currentIndex === 0) ? qsTr("Press and hold the button \"T\" to talk.") :
-                                qsTr("Press and hold grip triggers on your controllers to talk.");
+                                qsTr("Press and hold grip triggers on both controllers to talk.");
             }
         }
 
@@ -537,6 +537,7 @@ Rectangle {
                 anchors.verticalCenter: parent.verticalCenter;
                 size: 30;
             }
+
             RalewayRegular {
                 anchors.verticalCenter: parent.verticalCenter;
                 width: margins.sizeText + margins.sizeLevel;
@@ -546,26 +547,16 @@ Rectangle {
                 color: hifi.colors.white;
                 text: qsTr("Choose input device");
             }
-            AudioControls.LoopbackAudio {
-                id: loopbackAudio
-                x: margins.paddings
-                anchors.top: inputDeviceHeader.bottom;
-                anchors.topMargin: 10;
+        }
 
-                visible: (bar.currentIndex === 1 && isVR) ||
-                    (bar.currentIndex === 0 && !isVR);
-                anchors { left: parent.left; leftMargin: margins.paddings }
-            }
-
-            AudioControls.InputPeak {
-                id: inputLevel
-                anchors.right: parent.right
-                peak: model.peak;
-                anchors.verticalCenter: parent.verticalCenter
-                visible: ((bar.currentIndex === 1 && isVR) ||
-                    (bar.currentIndex === 0 && !isVR)) &&
-                    AudioScriptingInterface.devices.input.peakValuesAvailable;
-            }
+        AudioControls.LoopbackAudio {
+            id: loopbackAudio
+            x: margins.paddings
+            anchors.top: inputDeviceHeader.bottom;
+            anchors.topMargin: 10;
+            visible: (bar.currentIndex === 1 && isVR) ||
+                (bar.currentIndex === 0 && !isVR);
+            anchors { left: parent.left; leftMargin: margins.paddings }
         }
 
         ListView {
@@ -605,6 +596,15 @@ Rectangle {
                         }
                     }
                 }
+                AudioControls.InputPeak {
+                id: inputLevel
+                anchors.right: parent.right
+                peak: model.peak;
+                anchors.verticalCenter: parent.verticalCenter
+                visible: ((bar.currentIndex === 1 && isVR) ||
+                         (bar.currentIndex === 0 && !isVR)) &&
+                         AudioScriptingInterface.devices.input.peakValuesAvailable;
+                }
             }
         }
 
@@ -641,13 +641,13 @@ Rectangle {
                 color: hifi.colors.white;
                 text: qsTr("Choose output device");
             }
+        }
 
-            AudioControls.PlaySampleSound {
-                id: playSampleSound
-                x: margins.paddings
-                anchors.top: outputDeviceHeader.bottom;
-                anchors.topMargin: 10;
-            }
+        AudioControls.PlaySampleSound {
+            id: playSampleSound
+            x: margins.paddings
+            anchors.top: outputDeviceHeader.bottom;
+            anchors.topMargin: 10;
         }
 
         ListView {
@@ -655,7 +655,7 @@ Rectangle {
             width: parent.width - margins.paddings*2
             x: margins.paddings;
             interactive: false;
-            height: contentHeight;
+            height: contentHeight + 10;
             anchors.top: playSampleSound.bottom;
             anchors.topMargin: 10;
             clip: true;
@@ -665,7 +665,6 @@ Rectangle {
                 height: ((type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1)) ?
                         (margins.sizeCheckBox > checkBoxOutput.implicitHeight ? margins.sizeCheckBox + 4 : checkBoxOutput.implicitHeight + 4) : 0
                 visible: (type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1)
-
                 AudioControls.CheckBox {
                     id: checkBoxOutput
                     width: parent.width
@@ -684,12 +683,5 @@ Rectangle {
                 }
             }
         }
-
-        // Spacer item
-        Item {
-            anchors.top: outputView.bottom;
-            anchors.topMargin: 10;
-        }
     }
-
 }

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -572,7 +572,7 @@ Rectangle {
         ListView {
             id: inputView;
             width: rightMostInputLevelPos;
-            anchors.top: (loopbackAudio.visible === 1) ? loopbackAudio.bottom : inputDeviceHeader.bottom;
+            anchors.top: loopbackAudio.visible ? loopbackAudio.bottom : inputDeviceHeader.bottom;
             anchors.topMargin: 10;
             x: margins.paddings
             interactive: false;

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -328,171 +328,7 @@ Rectangle {
                                 qsTr("Press and hold grip triggers on both of your controllers to talk.");
             }
         }
-
-        Separator {
-            id: secondSeparator;
-            anchors.top: pttTextContainer.visible ? pttTextContainer.bottom : switchesContainer.bottom;
-            anchors.topMargin: 10;
-        }
-
-        Item {
-            id: inputDeviceHeader
-            x: margins.paddings;
-            width: parent.width - margins.paddings*2;
-            height: 36;
-            anchors.top: secondSeparator.bottom;
-            anchors.topMargin: 10;
-
-            HiFiGlyphs {
-                width: margins.sizeCheckBox;
-                text: hifi.glyphs.mic;
-                color: hifi.colors.white;
-                anchors.left: parent.left;
-                anchors.leftMargin: -size/4; //the glyph has empty space at left about 25%
-                anchors.verticalCenter: parent.verticalCenter;
-                size: 30;
-            }
-            RalewayRegular {
-                anchors.verticalCenter: parent.verticalCenter;
-                width: margins.sizeText + margins.sizeLevel;
-                anchors.left: parent.left;
-                anchors.leftMargin: margins.sizeCheckBox;
-                size: 22;
-                color: hifi.colors.white;
-                text: qsTr("Choose input device");
-            }
-        }
-
-        ListView {
-            id: inputView;
-            width: rightMostInputLevelPos;
-            anchors.top: inputDeviceHeader.bottom;
-            anchors.topMargin: 10;
-            x: margins.paddings
-            interactive: false;
-            height: contentHeight;
-            
-            clip: true;
-            model: AudioScriptingInterface.devices.input;
-            delegate: Item {
-                width: rightMostInputLevelPos - margins.paddings*2
-                height: ((type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1)) ?  
-                        (margins.sizeCheckBox > checkBoxInput.implicitHeight ? margins.sizeCheckBox + 4 : checkBoxInput.implicitHeight + 4) : 0
-                visible: (type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1) 
-                AudioControls.CheckBox {
-                    id: checkBoxInput
-                    anchors.left: parent.left
-                    spacing: margins.sizeCheckBox - boxSize
-                    anchors.verticalCenter: parent.verticalCenter
-                    width: parent.width - inputLevel.width
-                    clip: true
-                    checkable: !checked
-                    checked: bar.currentIndex === 0 ? selectedDesktop : selectedHMD;
-                    boxSize: margins.sizeCheckBox / 2
-                    isRound: true
-                    text: devicename
-                    fontSize: 16;
-                    onPressed: {
-                        if (!checked) {
-                            stereoInput.checked = false;
-                            AudioScriptingInterface.setStereoInput(false); // the next selected audio device might not support stereo
-                            AudioScriptingInterface.setInputDevice(info, bar.currentIndex === 1);
-                        }
-                    }
-                }
-                AudioControls.InputPeak {
-                    id: inputLevel
-                    anchors.right: parent.right
-                    peak: model.peak;
-                    anchors.verticalCenter: parent.verticalCenter
-                    visible: ((bar.currentIndex === 1 && isVR) ||
-                             (bar.currentIndex === 0 && !isVR)) &&
-                             AudioScriptingInterface.devices.input.peakValuesAvailable;
-                }
-            }
-        }
-
-        AudioControls.LoopbackAudio {
-            id: loopbackAudio
-            x: margins.paddings
-            anchors.top: inputView.bottom;
-            anchors.topMargin: 10;
-
-            visible: (bar.currentIndex === 1 && isVR) ||
-                (bar.currentIndex === 0 && !isVR);
-            anchors { left: parent.left; leftMargin: margins.paddings }
-        }
-
-        Separator {
-            id: thirdSeparator;
-            anchors.top: loopbackAudio.visible ? loopbackAudio.bottom : inputView.bottom;
-            anchors.topMargin: 10;
-        }
-
-        Item {
-            id: outputDeviceHeader;
-            anchors.topMargin: 10;
-            anchors.top: thirdSeparator.bottom;
-            x: margins.paddings;
-            width: parent.width - margins.paddings*2
-            height: 36
-
-            HiFiGlyphs {
-                anchors.left: parent.left
-                anchors.leftMargin: -size/4 //the glyph has empty space at left about 25%
-                anchors.verticalCenter: parent.verticalCenter;
-                width: margins.sizeCheckBox
-                text: hifi.glyphs.unmuted;
-                color: hifi.colors.white;
-                size: 36;
-            }
-
-            RalewayRegular {
-                width: margins.sizeText + margins.sizeLevel
-                anchors.left: parent.left
-                anchors.leftMargin: margins.sizeCheckBox
-                anchors.verticalCenter: parent.verticalCenter;
-                size: 22;
-                color: hifi.colors.white;
-                text: qsTr("Choose output device");
-            }
-        }
-
-        ListView {
-            id: outputView
-            width: parent.width - margins.paddings*2
-            x: margins.paddings;
-            interactive: false;
-            height: contentHeight;
-            anchors.top: outputDeviceHeader.bottom;
-            anchors.topMargin: 10;
-            clip: true;
-            model: AudioScriptingInterface.devices.output;
-            delegate: Item {
-                width: rightMostInputLevelPos
-                height: ((type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1)) ? 
-                        (margins.sizeCheckBox > checkBoxOutput.implicitHeight ? margins.sizeCheckBox + 4 : checkBoxOutput.implicitHeight + 4) : 0
-                visible: (type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1) 
-
-                AudioControls.CheckBox {
-                    id: checkBoxOutput
-                    width: parent.width
-                    spacing: margins.sizeCheckBox - boxSize
-                    boxSize: margins.sizeCheckBox / 2
-                    isRound: true
-                    checked: bar.currentIndex === 0 ? selectedDesktop :  selectedHMD;
-                    checkable: !checked
-                    text: devicename
-                    fontSize: 16
-                    onPressed: {
-                        if (!checked) {
-                            AudioScriptingInterface.setOutputDevice(info, bar.currentIndex === 1);
-                        }
-                    }
-                }
-            }
-        }
-
+        
         Item {
             id: avatarGainContainer
             x: margins.paddings;
@@ -674,6 +510,170 @@ Rectangle {
                 color: hifi.colors.white;
                 horizontalAlignment: Text.AlignLeft;
                 verticalAlignment: Text.AlignTop;
+            }
+        }
+
+        Separator {
+            id: secondSeparator;
+            anchors.top: pttTextContainer.visible ? pttTextContainer.bottom : switchesContainer.bottom;
+            anchors.topMargin: 10;
+        }
+
+        Item {
+            id: inputDeviceHeader
+            x: margins.paddings;
+            width: parent.width - margins.paddings*2;
+            height: 36;
+            anchors.top: secondSeparator.bottom;
+            anchors.topMargin: 10;
+
+            HiFiGlyphs {
+                width: margins.sizeCheckBox;
+                text: hifi.glyphs.mic;
+                color: hifi.colors.white;
+                anchors.left: parent.left;
+                anchors.leftMargin: -size/4; //the glyph has empty space at left about 25%
+                anchors.verticalCenter: parent.verticalCenter;
+                size: 30;
+            }
+            RalewayRegular {
+                anchors.verticalCenter: parent.verticalCenter;
+                width: margins.sizeText + margins.sizeLevel;
+                anchors.left: parent.left;
+                anchors.leftMargin: margins.sizeCheckBox;
+                size: 22;
+                color: hifi.colors.white;
+                text: qsTr("Choose input device");
+            }
+        }
+
+        ListView {
+            id: inputView;
+            width: rightMostInputLevelPos;
+            anchors.top: inputDeviceHeader.bottom;
+            anchors.topMargin: 10;
+            x: margins.paddings
+            interactive: false;
+            height: contentHeight;
+            
+            clip: true;
+            model: AudioScriptingInterface.devices.input;
+            delegate: Item {
+                width: rightMostInputLevelPos - margins.paddings*2
+                height: ((type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1)) ?  
+                        (margins.sizeCheckBox > checkBoxInput.implicitHeight ? margins.sizeCheckBox + 4 : checkBoxInput.implicitHeight + 4) : 0
+                visible: (type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1) 
+                AudioControls.CheckBox {
+                    id: checkBoxInput
+                    anchors.left: parent.left
+                    spacing: margins.sizeCheckBox - boxSize
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: parent.width - inputLevel.width
+                    clip: true
+                    checkable: !checked
+                    checked: bar.currentIndex === 0 ? selectedDesktop : selectedHMD;
+                    boxSize: margins.sizeCheckBox / 2
+                    isRound: true
+                    text: devicename
+                    fontSize: 16;
+                    onPressed: {
+                        if (!checked) {
+                            stereoInput.checked = false;
+                            AudioScriptingInterface.setStereoInput(false); // the next selected audio device might not support stereo
+                            AudioScriptingInterface.setInputDevice(info, bar.currentIndex === 1);
+                        }
+                    }
+                }
+                AudioControls.InputPeak {
+                    id: inputLevel
+                    anchors.right: parent.right
+                    peak: model.peak;
+                    anchors.verticalCenter: parent.verticalCenter
+                    visible: ((bar.currentIndex === 1 && isVR) ||
+                             (bar.currentIndex === 0 && !isVR)) &&
+                             AudioScriptingInterface.devices.input.peakValuesAvailable;
+                }
+            }
+        }
+
+        AudioControls.LoopbackAudio {
+            id: loopbackAudio
+            x: margins.paddings
+            anchors.top: inputView.bottom;
+            anchors.topMargin: 10;
+
+            visible: (bar.currentIndex === 1 && isVR) ||
+                (bar.currentIndex === 0 && !isVR);
+            anchors { left: parent.left; leftMargin: margins.paddings }
+        }
+
+        Separator {
+            id: thirdSeparator;
+            anchors.top: loopbackAudio.visible ? loopbackAudio.bottom : inputView.bottom;
+            anchors.topMargin: 10;
+        }
+
+        Item {
+            id: outputDeviceHeader;
+            anchors.topMargin: 10;
+            anchors.top: thirdSeparator.bottom;
+            x: margins.paddings;
+            width: parent.width - margins.paddings*2
+            height: 36
+
+            HiFiGlyphs {
+                anchors.left: parent.left
+                anchors.leftMargin: -size/4 //the glyph has empty space at left about 25%
+                anchors.verticalCenter: parent.verticalCenter;
+                width: margins.sizeCheckBox
+                text: hifi.glyphs.unmuted;
+                color: hifi.colors.white;
+                size: 36;
+            }
+
+            RalewayRegular {
+                width: margins.sizeText + margins.sizeLevel
+                anchors.left: parent.left
+                anchors.leftMargin: margins.sizeCheckBox
+                anchors.verticalCenter: parent.verticalCenter;
+                size: 22;
+                color: hifi.colors.white;
+                text: qsTr("Choose output device");
+            }
+        }
+
+        ListView {
+            id: outputView
+            width: parent.width - margins.paddings*2
+            x: margins.paddings;
+            interactive: false;
+            height: contentHeight;
+            anchors.top: outputDeviceHeader.bottom;
+            anchors.topMargin: 10;
+            clip: true;
+            model: AudioScriptingInterface.devices.output;
+            delegate: Item {
+                width: rightMostInputLevelPos
+                height: ((type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1)) ? 
+                        (margins.sizeCheckBox > checkBoxOutput.implicitHeight ? margins.sizeCheckBox + 4 : checkBoxOutput.implicitHeight + 4) : 0
+                visible: (type != "hmd" && bar.currentIndex === 0) || (type != "desktop" && bar.currentIndex === 1) 
+
+                AudioControls.CheckBox {
+                    id: checkBoxOutput
+                    width: parent.width
+                    spacing: margins.sizeCheckBox - boxSize
+                    boxSize: margins.sizeCheckBox / 2
+                    isRound: true
+                    checked: bar.currentIndex === 0 ? selectedDesktop :  selectedHMD;
+                    checkable: !checked
+                    text: devicename
+                    fontSize: 16
+                    onPressed: {
+                        if (!checked) {
+                            AudioScriptingInterface.setOutputDevice(info, bar.currentIndex === 1);
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This PR moves the volume control up, so you don't have to scroll all the way to the bottom just to change your volume.

The "Test your voice" and "Test your sound" buttons have been moved to the top of their categories, so, again, you don't have to scroll down as much to test your stuff. This makes sense, since you might want to test your audio, before changing it. The most helpful audio device options also appear at the top of their list (at least on linux).

I also shortened the PushToTalk info text for VR, since that was longer than the window would show.

I tested this PR on Linux Mint 19.3
![1Auswahl_693](https://user-images.githubusercontent.com/11144627/85183203-33f34280-b28b-11ea-8370-90f2f4e7f4f1.png)