### PR TITLE
Remove script that no longer exists created by the Vive Pro Eye PR.

### DIFF
--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -34,8 +34,7 @@ var DEFAULT_SCRIPTS_COMBINED = [
     "system/miniTablet.js",
     "system/audioMuteOverlay.js",
     "system/inspect.js",
-    "system/keyboardShortcuts/keyboardShortcuts.js",
-    "system/hand-track-walk.js"
+    "system/keyboardShortcuts/keyboardShortcuts.js"
 ];
 var DEFAULT_SCRIPTS_SEPARATE = [
     "system/controllers/controllerScripts.js",


### PR DESCRIPTION
To solve the problem of on startup the script tried to load and cannot so a QML dialog box appears to that effect.