### PR TITLE
Fix illegal instruction in libaudio.dylib on OSX

### DIFF
--- a/libraries/shared/src/NumericalConstants.h
+++ b/libraries/shared/src/NumericalConstants.h
@@ -28,8 +28,8 @@ const float ARCSECONDS_PER_ARCMINUTE = 60.0f;
 const float ARCSECONDS_PER_DEGREE = ARCMINUTES_PER_DEGREE * ARCSECONDS_PER_ARCMINUTE;
 
 const float EPSILON = 0.000001f;    //smallish positive number - used as margin of error for some computations
-const float SQUARE_ROOT_OF_2 = (float)sqrt(2.0f);
-const float SQUARE_ROOT_OF_3 = (float)sqrt(3.0f);
+const float SQUARE_ROOT_OF_2 = 1.414214f;
+const float SQUARE_ROOT_OF_3 = 1.732051f;
 const float METERS_PER_DECIMETER  = 0.1f;
 const float METERS_PER_CENTIMETER = 0.01f;
 const float METERS_PER_MILLIMETER = 0.001f;


### PR DESCRIPTION
A report was made in #mac of this crash:
```

Thread 2 received signal SIGILL, Illegal instruction.
0x00000001105fc4e4 in __cxx_global_var_init () from /Users/davek/builds/project-athena/build/libraries/audio/Debug/libaudio.dylib
(gdb) bt
#0  0x00000001105fc4e4 in __cxx_global_var_init ()
   from /Users/davek/builds/project-athena/build/libraries/audio/Debug/libaudio.dylib
#1  0x00000001105fc529 in _GLOBAL__sub_I_AudioHRTF_avx512.cpp ()
   from /Users/davek/builds/project-athena/build/libraries/audio/Debug/libaudio.dylib
#2  0x0000000103897592 in ?? ()
#3  0x000000011e24f000 in ?? ()
#4  0x000000011f070000 in ?? () from /Users/davek/builds/project-athena/build/libraries/gl/Debug/libgl.dylib
#5  0x000000011056d000 in ?? ()
warning: (Internal error: pc 0x0 in read in psymtab, but not in symtab.)

#6  0x0000000000000000 in ?? ()
(gdb) disassemble /m
Dump of assembler code for function __cxx_global_var_init:
   0x00000001105fc4e0 <+0>:    push   %rbp
   0x00000001105fc4e1 <+1>:    mov    %rsp,%rbp
=> 0x00000001105fc4e4 <+4>:    vmovss 0xe1d2(%rip),%xmm0        # 0x11060a6c0
   0x00000001105fc4ee <+14>:    callq  0x1105fb690 <_ZL4sqrtf>
   0x00000001105fc4f3 <+19>:    vmovss %xmm0,0x187813(%rip)        # 0x110783d10 <_ZL16SQUARE_ROOT_OF_2>
   0x00000001105fc4fd <+29>:    pop    %rbp
   0x00000001105fc4fe <+30>:    retq   
   0x00000001105fc4ff <+31>:    nop
End of assembler dump.
(gdb) 
```

`vmovss` is an AVX instruction that seems missing on some Mac hardware. Looking into the issue, it turns out:

1. `cmake/macros/SetupHifiLibrary.cmake` [checks](https://github.com/kasenvr/project-athena/blob/master/cmake/macros/SetupHifiLibrary.cmake#L18) if AVX512 is supported (very new instruction type) by the compiler.
2. If the compiler supports it, `-mavx512f` is used to compile `libraries/audio/src/avx512/AudioHRTF_avx512.cpp`.
3. `AudioHRTF_avx512.cpp` contains a single function: `FIR_1x4_AVX512`, which is only called from `AudioHRTF.cpp` in the case where AVX is supported.

So, this would seem correct: the AVX code is isolated into a separate file, and only used if the CPU the code runs on actually supports these instructions, otherwise it runs an alternate implementation. However, it still crashes with SIGILL.

The issue turns out to be:

1. `-mavx512f` not only allows the programmer to intentionally use AVX512 functionality, but also allows GCC to generate AVX512 instructions on its own. It also seems to enable AVX instructions that are older than AVX512.
2. `AudioHRTF_avx512.cpp` includes `AudioHRTF.h`, which includes `AudioHelpers.h`, which includes `libraries/shared/src/NumericalConstants.h`, which [contains](https://github.com/kasenvr/project-athena/blob/master/libraries/shared/src/NumericalConstants.h#L31) `const float SQUARE_ROOT_OF_2 = (float)sqrt(2.0f);`.
3. `sqrt` is a function call, and in this particular case GCC doesn't replace it with a fixed value (probably due to the pragma in `AudioHRTF_avx512.cpp`), so this requires executing code at some point to initialize this value. And it just happens what when GCC compiles this file with `-mavx512f`, an AVX instruction is used.
4. This code is executed unconditionally, in an internally created by the compiler function called `__cxx_global_var_init`, bypassing the CPU check, and therefore crashing on CPUs without AVX.

The fix is to just remove the call to `sqrt()` and replace it with a hardcoded constant, so that no code needs to be run to initialize `SQUARE_ROOT_OF_2`. Declaring it as `constexpr` was also considered, but it turns out that while this works on GCC, it's non-standard so it'll probably break on other compilers.





