### PR TITLE
Add ability to paste entities to any host type

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5545,7 +5545,7 @@ bool Application::importEntities(const QString& urlOrFilename, const bool isObse
     return success;
 }
 
-QVector<EntityItemID> Application::pasteEntities(const QString entityHostType, const float x, const float y, const float z) {
+QVector<EntityItemID> Application::pasteEntities(const QString& entityHostType, float x, float y, float z) {
     return _entityClipboard->sendEntities(&_entityEditSender, getEntities()->getTree(), entityHostType, x, y, z);
 }
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5545,7 +5545,7 @@ bool Application::importEntities(const QString& urlOrFilename, const bool isObse
     return success;
 }
 
-QVector<EntityItemID> Application::pasteEntities(QString entityHostType, float x, float y, float z) {
+QVector<EntityItemID> Application::pasteEntities(const QString entityHostType, const float x, const float y, const float z) {
     return _entityClipboard->sendEntities(&_entityEditSender, getEntities()->getTree(), entityHostType, x, y, z);
 }
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4065,7 +4065,7 @@ std::map<QString, QString> Application::prepareServerlessDomainContents(QUrl dom
     bool success = tmpTree->readFromByteArray(domainURL.toString(), data);
     if (success) {
         tmpTree->reaverageOctreeElements();
-        tmpTree->sendEntities(&_entityEditSender, getEntities()->getTree(), 0, 0, 0);
+        tmpTree->sendEntities(&_entityEditSender, getEntities()->getTree(), nullptr, 0, 0, 0);
     }
     std::map<QString, QString> namedPaths = tmpTree->getNamedPaths();
 
@@ -5545,8 +5545,8 @@ bool Application::importEntities(const QString& urlOrFilename, const bool isObse
     return success;
 }
 
-QVector<EntityItemID> Application::pasteEntities(float x, float y, float z) {
-    return _entityClipboard->sendEntities(&_entityEditSender, getEntities()->getTree(), x, y, z);
+QVector<EntityItemID> Application::pasteEntities(QString entityHostType, float x, float y, float z) {
+    return _entityClipboard->sendEntities(&_entityEditSender, getEntities()->getTree(), entityHostType, x, y, z);
 }
 
 void Application::init() {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4065,7 +4065,7 @@ std::map<QString, QString> Application::prepareServerlessDomainContents(QUrl dom
     bool success = tmpTree->readFromByteArray(domainURL.toString(), data);
     if (success) {
         tmpTree->reaverageOctreeElements();
-        tmpTree->sendEntities(&_entityEditSender, getEntities()->getTree(), nullptr, 0, 0, 0);
+        tmpTree->sendEntities(&_entityEditSender, getEntities()->getTree(), "domain", 0, 0, 0);
     }
     std::map<QString, QString> namedPaths = tmpTree->getNamedPaths();
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -375,7 +375,7 @@ signals:
     void awayStateWhenFocusLostInVRChanged(bool enabled);
 
 public slots:
-    QVector<EntityItemID> pasteEntities(QString entityHostType, float x, float y, float z);
+    QVector<EntityItemID> pasteEntities(const QString& entityHostType, float x, float y, float z);
     bool exportEntities(const QString& filename, const QVector<QUuid>& entityIDs, const glm::vec3* givenOffset = nullptr);
     bool exportEntities(const QString& filename, float x, float y, float z, float scale);
     bool importEntities(const QString& url, const bool isObservable = true, const qint64 callerId = -1);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -375,7 +375,7 @@ signals:
     void awayStateWhenFocusLostInVRChanged(bool enabled);
 
 public slots:
-    QVector<EntityItemID> pasteEntities(float x, float y, float z);
+    QVector<EntityItemID> pasteEntities(QString entityHostType, float x, float y, float z);
     bool exportEntities(const QString& filename, const QVector<QUuid>& entityIDs, const glm::vec3* givenOffset = nullptr);
     bool exportEntities(const QString& filename, float x, float y, float z, float scale);
     bool importEntities(const QString& url, const bool isObservable = true, const qint64 callerId = -1);

--- a/interface/src/scripting/ClipboardScriptingInterface.cpp
+++ b/interface/src/scripting/ClipboardScriptingInterface.cpp
@@ -60,13 +60,13 @@ bool ClipboardScriptingInterface::importEntities(
     return retVal;
 }
 
-QVector<EntityItemID> ClipboardScriptingInterface::pasteEntities(glm::vec3 position, QString entityHostType) {
+QVector<EntityItemID> ClipboardScriptingInterface::pasteEntities(const glm::vec3& position, const QString& entityHostType) {
     QVector<EntityItemID> retVal;
     BLOCKING_INVOKE_METHOD(qApp, "pasteEntities",
                               Q_RETURN_ARG(QVector<EntityItemID>, retVal),
-                              Q_ARG(QString, entityHostType),
-                              Q_ARG(float, position.x),
-                              Q_ARG(float, position.y),
-                              Q_ARG(float, position.z));
+                              Q_ARG(const QString&, entityHostType),
+                              Q_ARG(const float&, position.x),
+                              Q_ARG(const float&, position.y),
+                              Q_ARG(const float&, position.z));
     return retVal;
 }

--- a/interface/src/scripting/ClipboardScriptingInterface.cpp
+++ b/interface/src/scripting/ClipboardScriptingInterface.cpp
@@ -60,10 +60,11 @@ bool ClipboardScriptingInterface::importEntities(
     return retVal;
 }
 
-QVector<EntityItemID> ClipboardScriptingInterface::pasteEntities(glm::vec3 position) {
+QVector<EntityItemID> ClipboardScriptingInterface::pasteEntities(glm::vec3 position, QString entityHostType) {
     QVector<EntityItemID> retVal;
     BLOCKING_INVOKE_METHOD(qApp, "pasteEntities",
                               Q_RETURN_ARG(QVector<EntityItemID>, retVal),
+                              Q_ARG(QString, entityHostType),
                               Q_ARG(float, position.x),
                               Q_ARG(float, position.y),
                               Q_ARG(float, position.z));

--- a/interface/src/scripting/ClipboardScriptingInterface.cpp
+++ b/interface/src/scripting/ClipboardScriptingInterface.cpp
@@ -60,13 +60,13 @@ bool ClipboardScriptingInterface::importEntities(
     return retVal;
 }
 
-QVector<EntityItemID> ClipboardScriptingInterface::pasteEntities(const glm::vec3& position, const QString& entityHostType) {
+QVector<EntityItemID> ClipboardScriptingInterface::pasteEntities(glm::vec3 position, const QString& entityHostType) {
     QVector<EntityItemID> retVal;
     BLOCKING_INVOKE_METHOD(qApp, "pasteEntities",
                               Q_RETURN_ARG(QVector<EntityItemID>, retVal),
                               Q_ARG(const QString&, entityHostType),
-                              Q_ARG(const float&, position.x),
-                              Q_ARG(const float&, position.y),
-                              Q_ARG(const float&, position.z));
+                              Q_ARG(float, position.x),
+                              Q_ARG(float, position.y),
+                              Q_ARG(float, position.z));
     return retVal;
 }

--- a/interface/src/scripting/ClipboardScriptingInterface.h
+++ b/interface/src/scripting/ClipboardScriptingInterface.h
@@ -117,10 +117,10 @@ public:
      * Pastes the contents of the clipboard into the domain.
      * @function Clipboard.pasteEntities
      * @param {Vec3} position -  The position to paste the clipboard contents at.
-     * @param {Entities.EntityHostType} [entityHostType="domain"] - The type of entity to create.
+     * @param {Entities.EntityHostType} [entityHostType="domain"] - The type of entities to create.
      * @returns {Uuid[]} The IDs of the new entities that were created as a result of the paste operation. If entities couldn't 
      *     be created then an empty array is returned.
-    */
+     */
     Q_INVOKABLE QVector<EntityItemID> pasteEntities(glm::vec3 position, const QString& entityHostType = "domain");
 };
 

--- a/interface/src/scripting/ClipboardScriptingInterface.h
+++ b/interface/src/scripting/ClipboardScriptingInterface.h
@@ -117,10 +117,11 @@ public:
      * Pastes the contents of the clipboard into the domain.
      * @function Clipboard.pasteEntities
      * @param {Vec3} position -  The position to paste the clipboard contents at.
+     * @param {Entities.EntityHostType} [entityHostType="domain"] - The type of entity to create.
      * @returns {Uuid[]} The IDs of the new entities that were created as a result of the paste operation. If entities couldn't 
      *     be created then an empty array is returned.
-     */
-    Q_INVOKABLE QVector<EntityItemID> pasteEntities(glm::vec3 position);
+    */
+    Q_INVOKABLE QVector<EntityItemID> pasteEntities(glm::vec3 position, QString entityHostType = "domain");
 };
 
 #endif // hifi_ClipboardScriptingInterface_h

--- a/interface/src/scripting/ClipboardScriptingInterface.h
+++ b/interface/src/scripting/ClipboardScriptingInterface.h
@@ -121,7 +121,7 @@ public:
      * @returns {Uuid[]} The IDs of the new entities that were created as a result of the paste operation. If entities couldn't 
      *     be created then an empty array is returned.
     */
-    Q_INVOKABLE QVector<EntityItemID> pasteEntities(const glm::vec3& position, const QString& entityHostType = "domain");
+    Q_INVOKABLE QVector<EntityItemID> pasteEntities(glm::vec3 position, const QString& entityHostType = "domain");
 };
 
 #endif // hifi_ClipboardScriptingInterface_h

--- a/interface/src/scripting/ClipboardScriptingInterface.h
+++ b/interface/src/scripting/ClipboardScriptingInterface.h
@@ -121,7 +121,7 @@ public:
      * @returns {Uuid[]} The IDs of the new entities that were created as a result of the paste operation. If entities couldn't 
      *     be created then an empty array is returned.
     */
-    Q_INVOKABLE QVector<EntityItemID> pasteEntities(glm::vec3 position, QString entityHostType = "domain");
+    Q_INVOKABLE QVector<EntityItemID> pasteEntities(const glm::vec3& position, const QString& entityHostType = "domain");
 };
 
 #endif // hifi_ClipboardScriptingInterface_h

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -2657,7 +2657,7 @@ QByteArray EntityTree::remapActionDataIDs(QByteArray actionData, QHash<EntityIte
 }
 
 QVector<EntityItemID> EntityTree::sendEntities(EntityEditPacketSender* packetSender, EntityTreePointer localTree,
-                                               QString entityHostType, float x, float y, float z) {
+                                               const QString& entityHostType, float x, float y, float z) {
     SendEntitiesOperationArgs args;
     args.ourTree = this;
     args.otherTree = localTree;

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -2657,11 +2657,12 @@ QByteArray EntityTree::remapActionDataIDs(QByteArray actionData, QHash<EntityIte
 }
 
 QVector<EntityItemID> EntityTree::sendEntities(EntityEditPacketSender* packetSender, EntityTreePointer localTree,
-                                               float x, float y, float z) {
+                                               QString entityHostType, float x, float y, float z) {
     SendEntitiesOperationArgs args;
     args.ourTree = this;
     args.otherTree = localTree;
     args.root = glm::vec3(x, y, z);
+    args.entityHostType = entityHostType;
     // If this is called repeatedly (e.g., multiple pastes with the same data), the new elements will clash unless we
     // use new identifiers.  We need to keep a map so that we can map parent identifiers correctly.
     QHash<EntityItemID, EntityItemID> map;
@@ -2750,6 +2751,10 @@ bool EntityTree::sendEntitiesOperation(const OctreeElementPointer& element, void
         EntityItemID oldID = item->getEntityItemID();
         EntityItemID newID = getMapped(oldID);
         EntityItemProperties properties = item->getProperties();
+        
+        if (args->entityHostType != nullptr) {
+            properties.setEntityHostTypeFromString(args->entityHostType);
+        }
 
         EntityItemID oldParentID = properties.getParentID();
         if (oldParentID.isInvalidID()) {  // no parent

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -2751,9 +2751,10 @@ bool EntityTree::sendEntitiesOperation(const OctreeElementPointer& element, void
         EntityItemID oldID = item->getEntityItemID();
         EntityItemID newID = getMapped(oldID);
         EntityItemProperties properties = item->getProperties();
-        
-        if (args->entityHostType != nullptr) {
-            properties.setEntityHostTypeFromString(args->entityHostType);
+
+        properties.setEntityHostTypeFromString(args->entityHostType);
+        if (properties.getEntityHostType() == entity::HostType::AVATAR) {
+            properties.setOwningAvatarID(AVATAR_SELF_ID);
         }
 
         EntityItemID oldParentID = properties.getParentID();

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -178,7 +178,7 @@ public:
     static QByteArray remapActionDataIDs(QByteArray actionData, QHash<EntityItemID, EntityItemID>& map);
 
     QVector<EntityItemID> sendEntities(EntityEditPacketSender* packetSender, EntityTreePointer localTree,
-                                       QString entityHostType, float x, float y, float z);
+                                       const QString& entityHostType, float x, float y, float z);
 
     void entityChanged(EntityItemPointer entity);
 

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -40,6 +40,7 @@ public:
 class SendEntitiesOperationArgs {
 public:
     glm::vec3 root;
+    QString entityHostType;
     EntityTree* ourTree;
     EntityTreePointer otherTree;
     QHash<EntityItemID, EntityItemID>* map;
@@ -177,7 +178,7 @@ public:
     static QByteArray remapActionDataIDs(QByteArray actionData, QHash<EntityItemID, EntityItemID>& map);
 
     QVector<EntityItemID> sendEntities(EntityEditPacketSender* packetSender, EntityTreePointer localTree,
-                                       float x, float y, float z);
+                                       QString entityHostType, float x, float y, float z);
 
     void entityChanged(EntityItemPointer entity);
 


### PR DESCRIPTION
It defaults to "domain" if not specified.

Closes #488 

Test plan, make sure that:
- you can still call the method without specifying host type
- it works for all three host types and that the functionality works as expected for all three host types.