### PR TITLE
Increase maximum texture size to 8192

### DIFF
--- a/interface/src/ModelPackager.cpp
+++ b/interface/src/ModelPackager.cpp
@@ -24,7 +24,7 @@
 #include "ModelPropertiesDialog.h"
 #include "InterfaceLogging.h"
 
-static const int MAX_TEXTURE_SIZE = 1024;
+static const int MAX_TEXTURE_SIZE = 8192;
 
 void copyDirectoryContent(QDir& from, QDir& to) {
     for (auto entry : from.entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot |

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -51,7 +51,7 @@ using ColorType = glm::vec3;
 #define HFM_COLOR_ELEMENT gpu::Element::VEC3F_XYZ
 #endif
 
-const int MAX_NUM_PIXELS_FOR_FBX_TEXTURE = 2048 * 2048;
+const int MAX_NUM_PIXELS_FOR_FBX_TEXTURE = 8192 * 8192;
 
 
 using ShapeVertices = std::vector<glm::vec3>;

--- a/libraries/image/src/image/TextureProcessing.cpp
+++ b/libraries/image/src/image/TextureProcessing.cpp
@@ -41,7 +41,7 @@ using namespace gpu;
 
 static const glm::uvec2 SPARSE_PAGE_SIZE(128);
 static const glm::uvec2 MAX_TEXTURE_SIZE_GLES(2048);
-static const glm::uvec2 MAX_TEXTURE_SIZE_GL(4096);
+static const glm::uvec2 MAX_TEXTURE_SIZE_GL(8192);
 bool DEV_DECIMATE_TEXTURES = false;
 std::atomic<size_t> DECIMATED_TEXTURE_COUNT{ 0 };
 std::atomic<size_t> RECTIFIED_TEXTURE_COUNT{ 0 };


### PR DESCRIPTION
There is interest in increasing the maximum texture size. This seems reasonable, since most of our users own their own domain, and decide which kinds of users to target, so there seems little need to restrict them.

According to https://feedback.wildfiregames.com/report/opengl/feature/GL_MAX_TEXTURE_SIZE the 8192 size should be supported by 90% of the surveyed hardware, which includes 10 year old cards. That seems quite reasonable.

This needs testing to see if:

1. A 8192x8192 texture actually works
2. What happens when it's used on hardware that doesn't support it (if we can find hardware old enough)
