### PR TITLE
Fix/move user agent

### DIFF
--- a/assignment-client/src/avatars/ScriptableAvatar.cpp
+++ b/assignment-client/src/avatars/ScriptableAvatar.cpp
@@ -23,6 +23,7 @@
 #include <AvatarLogging.h>
 #include <EntityItem.h>
 #include <EntityItemProperties.h>
+#include <NetworkingConstants.h>
 
 
 ScriptableAvatar::ScriptableAvatar() {
@@ -221,7 +222,7 @@ void ScriptableAvatar::updateJointMappings() {
         QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
         QNetworkRequest networkRequest = QNetworkRequest(_skeletonModelURL);
         networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-        networkRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+        networkRequest.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
         DependencyManager::get<ResourceRequestObserver>()->update(
             _skeletonModelURL, -1, "AvatarData::updateJointMappings");
         QNetworkReply* networkReply = networkAccessManager.get(networkRequest);

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -122,7 +122,7 @@ bool DomainServer::forwardMetaverseAPIRequest(HTTPConnection* connection,
     QUrl url{ MetaverseAPI::getCurrentMetaverseServerURL().toString() + metaversePath };
 
     QNetworkRequest req(url);
-    req.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+    req.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
     req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
 
     if (accessTokenVariant.isValid()) {
@@ -2458,7 +2458,7 @@ bool DomainServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url
             url.setQuery("access_token=" + accessTokenVariant.toString());
 
             QNetworkRequest req(url);
-            req.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+            req.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
             req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
             QNetworkReply* reply = NetworkAccessManager::getInstance().put(req, doc.toJson());
 
@@ -2559,7 +2559,7 @@ bool DomainServer::handleHTTPSRequest(HTTPSConnection* connection, const QUrl &u
 
             QNetworkRequest tokenRequest(tokenRequestUrl);
             tokenRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-            tokenRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+            tokenRequest.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
             tokenRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
             QNetworkReply* tokenReply = NetworkAccessManager::getInstance().post(tokenRequest, tokenPostBody.toLocal8Bit());
@@ -2871,7 +2871,7 @@ QNetworkReply* DomainServer::profileRequestGivenTokenReply(QNetworkReply* tokenR
 
     QNetworkRequest profileRequest(profileURL);
     profileRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-    profileRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+    profileRequest.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
     return NetworkAccessManager::getInstance().get(profileRequest);
 }
 

--- a/interface/resources/qml/controls/+webengine/FlickableWebViewCore.qml
+++ b/interface/resources/qml/controls/+webengine/FlickableWebViewCore.qml
@@ -137,7 +137,7 @@ Item {
             if (webViewCoreUserAgent !== undefined) {
                 webViewCore.profile.httpUserAgent = webViewCoreUserAgent
             } else {
-                webViewCore.profile.httpUserAgent += " (HighFidelityInterface)";
+                webViewCore.profile.httpUserAgent += " (VircadiaInterface)";
             }
             // Ensure the JS from the web-engine makes it to our logging
             webViewCore.javaScriptConsoleMessage.connect(function(level, message, lineNumber, sourceID) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -7655,7 +7655,7 @@ bool Application::askToWearAvatarAttachmentUrl(const QString& url) {
     QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
     QNetworkRequest networkRequest = QNetworkRequest(url);
     networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-    networkRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+    networkRequest.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
     QNetworkReply* reply = networkAccessManager.get(networkRequest);
     int requestNumber = ++_avatarAttachmentRequest;
     connect(reply, &QNetworkReply::finished, [this, reply, url, requestNumber]() {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2614,7 +2614,7 @@ QString Application::getUserAgent() {
         return userAgent;
     }
 
-    QString userAgent = "Mozilla/5.0 (HighFidelityInterface/" + BuildInfo::VERSION + "; "
+    QString userAgent = NetworkingConstants::VIRCADIA_USER_AGENT + "/" + BuildInfo::VERSION + "; "
         + QSysInfo::productType() + " " + QSysInfo::productVersion() + ")";
 
     auto formatPluginName = [](QString name) -> QString { return name.trimmed().replace(" ", "-");  };

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -722,7 +722,7 @@ public:
      * @function MyAvatar.restoreHandAnimation
      * @param isLeft {boolean} Set to true if using the left hand
      * @example <caption> Override left hand animation for three seconds. </caption>
-     * var ANIM_URL = "https://apidocs.projectathena.dev/models/ClapHands_Standing.fbx";
+     * var ANIM_URL = "https://apidocs.vircadia.dev/models/ClapHands_Standing.fbx";
      * MyAvatar.overrideHandAnimation(isLeft, ANIM_URL, 30, true, 0, 53);
      * Script.setTimeout(function () {
      *     MyAvatar.restoreHandAnimation();
@@ -780,7 +780,7 @@ public:
      * hanging at its sides when it is not moving, the avatar will stand and clap its hands. Note that just as it did before, as soon as the avatar
      * starts to move, the animation will smoothly blend into the walk animation used by the "walkFwd" animation role.</caption>
      * // An animation of the avatar clapping its hands while standing. Restore default after 30s.
-     * var ANIM_URL = "https://apidocs.projectathena.dev/models/ClapHands_Standing.fbx";
+     * var ANIM_URL = "https://apidocs.vircadia.dev/models/ClapHands_Standing.fbx";
      * MyAvatar.overrideRoleAnimation("idleStand", ANIM_URL, 30, true, 0, 53);
      * Script.setTimeout(function () {
      *     MyAvatar.restoreRoleAnimation();

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -29,6 +29,7 @@
 #include "Menu.h"
 #include "OffscreenUi.h"
 #include "commerce/QmlCommerce.h"
+#include "NetworkingConstants.h"
 
 static const QString DESKTOP_LOCATION = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
 static const QString LAST_BROWSE_LOCATION_SETTING = "LastBrowseLocation";
@@ -409,6 +410,10 @@ void WindowScriptingInterface::showAssetServer(const QString& upload) {
 
 QString WindowScriptingInterface::checkVersion() {
     return QCoreApplication::applicationVersion();
+}
+
+QString WindowScriptingInterface::getUserAgent() {
+    return NetworkingConstants::VIRCADIA_USER_AGENT;
 }
 
 QString WindowScriptingInterface::protocolSignature() {

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -296,6 +296,13 @@ public slots:
     QString checkVersion();
 
     /**jsdoc
+     * Gets Interface's user agent.
+     * @function Window.getUserAgent
+     * @returns {string} Interface's user agent.
+     */
+    QString getUserAgent();
+
+    /**jsdoc
      * Gets the signature for Interface's protocol version.
      * @function Window.protocolSignature
      * @returns {string} A string uniquely identifying the version of the metaverse protocol that Interface is using.

--- a/interface/src/ui/ModelsBrowser.cpp
+++ b/interface/src/ui/ModelsBrowser.cpp
@@ -27,6 +27,7 @@
 
 #include <ThreadHelpers.h>
 #include <NetworkAccessManager.h>
+#include <NetworkingConstants.h>
 #include <SharedUtil.h>
 
 const char* MODEL_TYPE_NAMES[] = { "entities", "heads", "skeletons", "skeletons", "attachments" };
@@ -225,7 +226,7 @@ void ModelHandler::update() {
         QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
         QNetworkRequest request(url);
         request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-        request.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+        request.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
         QNetworkReply* reply = networkAccessManager.head(request);
         connect(reply, SIGNAL(finished()), SLOT(downloadFinished()));
     }
@@ -278,7 +279,7 @@ void ModelHandler::queryNewFiles(QString marker) {
     QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
     QNetworkRequest request(url);
     request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-    request.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+    request.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
     QNetworkReply* reply = networkAccessManager.get(request);
     connect(reply, SIGNAL(finished()), SLOT(downloadFinished()));
             

--- a/libraries/auto-updater/src/AutoUpdater.cpp
+++ b/libraries/auto-updater/src/AutoUpdater.cpp
@@ -51,7 +51,7 @@ void AutoUpdater::getLatestVersionData() {
     QNetworkRequest latestVersionRequest(buildsURL);
 
     latestVersionRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-    latestVersionRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+    latestVersionRequest.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
     QNetworkReply* reply = networkAccessManager.get(latestVersionRequest);
     connect(reply, &QNetworkReply::finished, this, &AutoUpdater::parseLatestVersionData);
 }

--- a/libraries/baking/src/JSBaker.cpp
+++ b/libraries/baking/src/JSBaker.cpp
@@ -14,6 +14,7 @@
 #include <QtNetwork/QNetworkReply>
 
 #include <NetworkAccessManager.h>
+#include <NetworkingConstants.h>
 #include <SharedUtil.h>
 #include <PathUtils.h>
 
@@ -62,7 +63,7 @@ void JSBaker::loadScript() {
         // setup the request to follow re-directs and always hit the network
         networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
         networkRequest.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork);
-        networkRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+        networkRequest.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
 
         networkRequest.setUrl(_jsURL);
 

--- a/libraries/baking/src/ModelBaker.cpp
+++ b/libraries/baking/src/ModelBaker.cpp
@@ -13,6 +13,7 @@
 
 #include <PathUtils.h>
 #include <NetworkAccessManager.h>
+#include <NetworkingConstants.h>
 
 #include <DependencyManager.h>
 #include <hfm/ModelFormatRegistry.h>
@@ -159,7 +160,7 @@ void ModelBaker::saveSourceModel() {
         // setup the request to follow re-directs and always hit the network
         networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
         networkRequest.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork);
-        networkRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+        networkRequest.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
 
         networkRequest.setUrl(_modelURL);
 

--- a/libraries/baking/src/TextureBaker.cpp
+++ b/libraries/baking/src/TextureBaker.cpp
@@ -19,6 +19,7 @@
 #include <image/TextureProcessing.h>
 #include <ktx/KTX.h>
 #include <NetworkAccessManager.h>
+#include <NetworkingConstants.h>
 #include <SharedUtil.h>
 #include <TextureMeta.h>
 
@@ -99,7 +100,7 @@ void TextureBaker::loadTexture() {
         // setup the request to follow re-directs and always hit the network
         networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
         networkRequest.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork);
-        networkRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+        networkRequest.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
 
         networkRequest.setUrl(_textureURL);
 

--- a/libraries/fbx/src/FSTReader.cpp
+++ b/libraries/fbx/src/FSTReader.cpp
@@ -17,6 +17,7 @@
 #include <QNetworkRequest>
 
 #include <NetworkAccessManager.h>
+#include <NetworkingConstants.h>
 #include <SharedUtil.h>
 
 QVariantHash FSTReader::parseMapping(QIODevice* device) {
@@ -253,7 +254,7 @@ QVariantHash FSTReader::downloadMapping(const QString& url) {
     QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
     QNetworkRequest networkRequest = QNetworkRequest(url);
     networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-    networkRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+    networkRequest.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
     QNetworkReply* reply = networkAccessManager.get(networkRequest);
     QEventLoop loop;
     QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -58,7 +58,7 @@ const auto METAVERSE_SESSION_ID_HEADER = QString("HFM-SessionID").toLocal8Bit();
 
 using UserAgentGetter = std::function<QString()>;
 
-const auto DEFAULT_USER_AGENT_GETTER = []() -> QString { return HIGH_FIDELITY_USER_AGENT; };
+const auto DEFAULT_USER_AGENT_GETTER = []() -> QString { return NetworkingConstants::VIRCADIA_USER_AGENT; };
 
 class AccountManager : public QObject, public Dependency {
     Q_OBJECT

--- a/libraries/networking/src/HTTPResourceRequest.cpp
+++ b/libraries/networking/src/HTTPResourceRequest.cpp
@@ -21,6 +21,7 @@
 
 #include "NetworkAccessManager.h"
 #include "NetworkLogging.h"
+#include "NetworkingConstants.h"
 
 HTTPResourceRequest::~HTTPResourceRequest() {
     if (_reply) {
@@ -54,7 +55,7 @@ void HTTPResourceRequest::doSend() {
 
     QNetworkRequest networkRequest(_url);
     networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-    networkRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+    networkRequest.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
 
     if (_cacheEnabled) {
         networkRequest.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache);

--- a/libraries/networking/src/NetworkingConstants.h
+++ b/libraries/networking/src/NetworkingConstants.h
@@ -30,6 +30,9 @@ namespace NetworkingConstants {
 
     // Web Engine requests to this parent domain have an account authorization header added
     const QString AUTH_HOSTNAME_BASE = "highfidelity.com";
+    
+    // Use a custom User-Agent to avoid ModSecurity filtering, e.g. by hosting providers.
+    const QByteArray VIRCADIA_USER_AGENT = "Mozilla/5.0 (HighFidelityInterface)";
 
     const QUrl BUILDS_XML_URL("https://highfidelity.com/builds.xml");
     const QUrl MASTER_BUILDS_XML_URL("https://highfidelity.com/dev-builds.xml");

--- a/libraries/networking/src/NetworkingConstants.h
+++ b/libraries/networking/src/NetworkingConstants.h
@@ -30,9 +30,14 @@ namespace NetworkingConstants {
 
     // Web Engine requests to this parent domain have an account authorization header added
     const QString AUTH_HOSTNAME_BASE = "highfidelity.com";
+    const QStringList IS_AUTHABLE_HOSTNAME = { "highfidelity.com", "highfidelity.io" };
     
     // Use a custom User-Agent to avoid ModSecurity filtering, e.g. by hosting providers.
     const QByteArray VIRCADIA_USER_AGENT = "Mozilla/5.0 (VircadiaInterface)";
+    
+    const QString WEB_ENGINE_USER_AGENT = "Chrome/48.0 (VircadiaInterface)";
+    const QString METAVERSE_USER_AGENT = "Chrome/48.0 (VircadiaInterface)";
+    const QString MOBILE_USER_AGENT = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36";
 
     const QUrl BUILDS_XML_URL("https://highfidelity.com/builds.xml");
     const QUrl MASTER_BUILDS_XML_URL("https://highfidelity.com/dev-builds.xml");

--- a/libraries/networking/src/NetworkingConstants.h
+++ b/libraries/networking/src/NetworkingConstants.h
@@ -32,7 +32,7 @@ namespace NetworkingConstants {
     const QString AUTH_HOSTNAME_BASE = "highfidelity.com";
     
     // Use a custom User-Agent to avoid ModSecurity filtering, e.g. by hosting providers.
-    const QByteArray VIRCADIA_USER_AGENT = "Mozilla/5.0 (HighFidelityInterface)";
+    const QByteArray VIRCADIA_USER_AGENT = "Mozilla/5.0 (VircadiaInterface)";
 
     const QUrl BUILDS_XML_URL("https://highfidelity.com/builds.xml");
     const QUrl MASTER_BUILDS_XML_URL("https://highfidelity.com/dev-builds.xml");

--- a/libraries/networking/src/OAuthNetworkAccessManager.cpp
+++ b/libraries/networking/src/OAuthNetworkAccessManager.cpp
@@ -39,7 +39,7 @@ QNetworkReply* OAuthNetworkAccessManager::createRequest(QNetworkAccessManager::O
         && req.url().host() == MetaverseAPI::getCurrentMetaverseServerURL().host()) {
         QNetworkRequest authenticatedRequest(req);
         authenticatedRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-        authenticatedRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+        authenticatedRequest.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
         authenticatedRequest.setRawHeader(ACCESS_TOKEN_AUTHORIZATION_HEADER,
                                           accountManager->getAccountInfo().getAccessToken().authorizationHeaderValue());
         

--- a/libraries/networking/src/ResourceManager.cpp
+++ b/libraries/networking/src/ResourceManager.cpp
@@ -25,6 +25,7 @@
 #include "HTTPResourceRequest.h"
 #include "NetworkAccessManager.h"
 #include "NetworkLogging.h"
+#include "NetworkingConstants.h"
 
 ResourceManager::ResourceManager(bool atpSupportEnabled) : _atpSupportEnabled(atpSupportEnabled) {
     _thread.setObjectName("Resource Manager Thread");
@@ -157,7 +158,7 @@ bool ResourceManager::resourceExists(const QUrl& url) {
         QNetworkRequest request{ url };
 
         request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-        request.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+        request.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
 
         auto reply = networkAccessManager.head(request);
 

--- a/libraries/networking/src/SandboxUtils.cpp
+++ b/libraries/networking/src/SandboxUtils.cpp
@@ -22,6 +22,7 @@
 
 #include "NetworkAccessManager.h"
 #include "NetworkLogging.h"
+#include "NetworkingConstants.h"
 
 namespace SandboxUtils {
 
@@ -29,7 +30,7 @@ QNetworkReply* getStatus() {
     auto& networkAccessManager = NetworkAccessManager::getInstance();
     QNetworkRequest sandboxStatus(SANDBOX_STATUS_URL);
     sandboxStatus.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-    sandboxStatus.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+    sandboxStatus.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
     return networkAccessManager.get(sandboxStatus);
 }
 

--- a/libraries/render-utils/src/text/Font.cpp
+++ b/libraries/render-utils/src/text/Font.cpp
@@ -15,6 +15,7 @@
 #include "../StencilMaskPass.h"
 
 #include "NetworkAccessManager.h"
+#include "NetworkingConstants.h"
 
 static std::mutex fontMutex;
 
@@ -97,7 +98,7 @@ Font::Pointer Font::load(const QString& family) {
 
             QNetworkRequest networkRequest;
             networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-            networkRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+            networkRequest.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
             networkRequest.setUrl(family);
 
             auto networkReply = networkAccessManager.get(networkRequest);

--- a/libraries/script-engine/src/ScriptsModel.cpp
+++ b/libraries/script-engine/src/ScriptsModel.cpp
@@ -16,6 +16,7 @@
 #include <QDirIterator>
 
 #include <NetworkAccessManager.h>
+#include <NetworkingConstants.h>
 #include <PathUtils.h>
 
 #include "ScriptEngine.h"
@@ -191,7 +192,7 @@ void ScriptsModel::requestDefaultFiles(QString marker) {
             QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
             QNetworkRequest request(url);
             request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-            request.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+            request.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
             QNetworkReply* reply = networkAccessManager.get(request);
             connect(reply, SIGNAL(finished()), SLOT(downloadFinished()));
         }

--- a/libraries/script-engine/src/XMLHttpRequestClass.cpp
+++ b/libraries/script-engine/src/XMLHttpRequestClass.cpp
@@ -62,7 +62,7 @@ void XMLHttpRequestClass::abort() {
 }
 
 void XMLHttpRequestClass::setRequestHeader(const QString& name, const QString& value) {
-    _request.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
+    _request.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
     _request.setRawHeader(QByteArray(name.toLatin1()), QByteArray(value.toLatin1()));
 }
 

--- a/libraries/shared/src/SharedUtil.h
+++ b/libraries/shared/src/SharedUtil.h
@@ -81,9 +81,6 @@ const int BYTES_PER_FLAGS = 1;
 typedef unsigned char colorPart;
 typedef unsigned char nodeColor[BYTES_PER_COLOR + BYTES_PER_FLAGS];
 
-// Use a custom User-Agent to avoid ModSecurity filtering, e.g. by hosting providers.
-const QByteArray HIGH_FIDELITY_USER_AGENT = "Mozilla/5.0 (HighFidelityInterface)";
-
 // Equivalent to time_t but in usecs instead of secs
 quint64 usecTimestampNow(bool wantDebug = false);
 void usecTimestampNowForceClockSkew(qint64 clockSkew);

--- a/libraries/ui/src/ui/types/FileTypeProfile.cpp
+++ b/libraries/ui/src/ui/types/FileTypeProfile.cpp
@@ -16,6 +16,7 @@
 #include <QtQml/QQmlContext>
 
 #include "RequestFilters.h"
+#include "NetworkingConstants.h"
 
 #if !defined(Q_OS_ANDROID)
 static const QString QML_WEB_ENGINE_STORAGE_NAME = "qmlWebEngine";
@@ -26,8 +27,7 @@ static std::mutex FileTypeProfile_mutex;
 FileTypeProfile::FileTypeProfile(QQmlContext* parent) :
     ContextAwareProfile(parent)
 {
-    static const QString WEB_ENGINE_USER_AGENT = "Chrome/48.0 (HighFidelityInterface)";
-    setHttpUserAgent(WEB_ENGINE_USER_AGENT);
+    setHttpUserAgent(NetworkingConstants::WEB_ENGINE_USER_AGENT);
 
     setStorageName(QML_WEB_ENGINE_STORAGE_NAME);
     setOffTheRecord(false);

--- a/libraries/ui/src/ui/types/RequestFilters.cpp
+++ b/libraries/ui/src/ui/types/RequestFilters.cpp
@@ -27,10 +27,10 @@ namespace {
 
     bool isAuthableHighFidelityURL(const QUrl& url) {
         auto metaverseServerURL = MetaverseAPI::getCurrentMetaverseServerURL();
-        static const QStringList HF_HOSTS = {
-            "highfidelity.com", "highfidelity.io",
-            metaverseServerURL.toString(),
+        static QStringList HF_HOSTS = {
+            metaverseServerURL.toString()
         };
+        HF_HOSTS << NetworkingConstants::IS_AUTHABLE_HOSTNAME;
         const auto& scheme = url.scheme();
         const auto& host = url.host();
 
@@ -83,8 +83,8 @@ void RequestFilters::interceptHFWebEngineRequest(QWebEngineUrlRequestInfo& info,
         }
     }
     static const QString USER_AGENT = "User-Agent";
-    const QString tokenStringMobile{ "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36" };
-    const QString tokenStringMetaverse{ "Chrome/48.0 (HighFidelityInterface)" };
+    const QString tokenStringMobile{ NetworkingConstants::MOBILE_USER_AGENT };
+    const QString tokenStringMetaverse{ NetworkingConstants::METAVERSE_USER_AGENT };
     const QString tokenStringLimitedCommerce{ "Chrome/48.0 (HighFidelityInterface limitedCommerce)" };
 
     const QString tokenString = !isAuthable ? tokenStringMobile : (accountManager->getLimitedCommerce() ? tokenStringLimitedCommerce : tokenStringMetaverse);

--- a/libraries/ui/src/ui/types/RequestFilters.cpp
+++ b/libraries/ui/src/ui/types/RequestFilters.cpp
@@ -85,7 +85,7 @@ void RequestFilters::interceptHFWebEngineRequest(QWebEngineUrlRequestInfo& info,
     static const QString USER_AGENT = "User-Agent";
     const QString tokenStringMobile{ NetworkingConstants::MOBILE_USER_AGENT };
     const QString tokenStringMetaverse{ NetworkingConstants::METAVERSE_USER_AGENT };
-    const QString tokenStringLimitedCommerce{ "Chrome/48.0 (HighFidelityInterface limitedCommerce)" };
+    const QString tokenStringLimitedCommerce{ "Chrome/48.0 (VircadiaInterface limitedCommerce)" };
 
     const QString tokenString = !isAuthable ? tokenStringMobile : (accountManager->getLimitedCommerce() ? tokenStringLimitedCommerce : tokenStringMetaverse);
     info.setHttpHeader(USER_AGENT.toLocal8Bit(), tokenString.toLocal8Bit());


### PR DESCRIPTION
This PR updates two links for JSDocs and then renames the `HIGH_FIDELITY_USER_AGENT` to `VIRCADIA_USER_AGENT` and moves it to NetworkingConstants.h so that these sorts of things are slowly more centralized for customization/changing over time.

Functionality should not change, everything should work exactly the same.