### PR TITLE
Change strings, comments and folders to Vircadia rebrand

### DIFF
--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -121,14 +121,14 @@ if (APPLE)
   # configure CMake to use a custom Info.plist
   set_target_properties(${this_target} PROPERTIES MACOSX_BUNDLE_INFO_PLIST MacOSXBundleInfo.plist.in)
 
-  set(MACOSX_BUNDLE_BUNDLE_NAME "High Fidelity")
+  set(MACOSX_BUNDLE_BUNDLE_NAME "Vircadia")
   if (PRODUCTION_BUILD)
-    set(MACOSX_BUNDLE_GUI_IDENTIFIER com.highfidelity.interface)
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER com.vircadia.interface)
   else ()
     if (DEV_BUILD)
-      set(MACOSX_BUNDLE_GUI_IDENTIFIER com.highfidelity.interface-dev)
+      set(MACOSX_BUNDLE_GUI_IDENTIFIER com.vircadia.interface-dev)
     elseif (PR_BUILD)
-      set(MACOSX_BUNDLE_GUI_IDENTIFIER com.highfidelity.interface-pr)
+      set(MACOSX_BUNDLE_GUI_IDENTIFIER com.vircadia.interface-pr)
     endif ()
   endif ()
 

--- a/launchers/darwin/CMakeLists.txt
+++ b/launchers/darwin/CMakeLists.txt
@@ -143,13 +143,13 @@ set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR})
 include(CPackComponent)
 
 set(CPACK_PACKAGE_NAME "HQ Launcher")
-set(CPACK_PACKAGE_VENDOR "High Fidelity")
+set(CPACK_PACKAGE_VENDOR "Vircadia")
 set(CPACK_PACKAGE_VERSION ${BUILD_VERSION})
 set(CPACK_PACKAGE_FILE_NAME "HQ Launcher")
 
 set(CPACK_NSIS_DISPLAY_NAME ${_DISPLAY_NAME})
 
-set(DMG_SUBFOLDER_NAME "High Fidelity")
+set(DMG_SUBFOLDER_NAME "Vircadia")
 set(ESCAPED_DMG_SUBFOLDER_NAME "")
 set(DMG_SUBFOLDER_ICON "${CMAKE_SOURCE_DIR}/cmake/installer/install-folder.rsrc")
 

--- a/launchers/qt/CMakeLists.txt
+++ b/launchers/qt/CMakeLists.txt
@@ -276,12 +276,12 @@ if (APPLE)
   include(CPackComponent)
 
   set(CPACK_PACKAGE_NAME "HQ Launcher")
-  set(CPACK_PACKAGE_VENDOR "High Fidelity")
+  set(CPACK_PACKAGE_VENDOR "Vircadia")
   set(CPACK_PACKAGE_FILE_NAME "HQ Launcher")
 
   set(CPACK_NSIS_DISPLAY_NAME ${_DISPLAY_NAME})
 
-  set(DMG_SUBFOLDER_NAME "High Fidelity")
+  set(DMG_SUBFOLDER_NAME "Vircadia")
   set(ESCAPED_DMG_SUBFOLDER_NAME "")
   set(DMG_SUBFOLDER_ICON "${CMAKE_SOURCE_DIR}/cmake/installer/install-folder.rsrc")
 

--- a/launchers/qt/resources/qml/HFControls/HFTextLogo.qml
+++ b/launchers/qt/resources/qml/HFControls/HFTextLogo.qml
@@ -2,7 +2,7 @@ import QtQuick 2.3
 import QtQuick 2.1
 
 Text {
-    text: "High Fidelity"
+    text: "Vircadia"
     font.bold: true
     font.family: "Graphik Semibold"
     font.pixelSize: 17

--- a/launchers/qt/src/Launcher.cpp
+++ b/launchers/qt/src/Launcher.cpp
@@ -21,7 +21,7 @@ Launcher::Launcher(int& argc, char**argv) : QGuiApplication(argc, argv) {
     _launcherWindow->rootContext()->setContextProperty("LauncherState", _launcherState.get());
     _launcherWindow->rootContext()->setContextProperty("PathUtils", new PathUtils());
     _launcherWindow->rootContext()->setContextProperty("Platform", platform);
-    _launcherWindow->setTitle("High Fidelity");
+    _launcherWindow->setTitle("Vircadia");
     _launcherWindow->setFlags(Qt::FramelessWindowHint | Qt::Window);
     _launcherWindow->setLauncherStatePtr(_launcherState);
 

--- a/launchers/qt/src/LauncherInstaller_windows.cpp
+++ b/launchers/qt/src/LauncherInstaller_windows.cpp
@@ -12,7 +12,7 @@
 
 #include <QStandardPaths>
 #include <QFileInfo>
-#include <QFile> 
+#include <QFile>
 #include <QDebug>
 #include <QTime>
 
@@ -253,7 +253,7 @@ void LauncherInstaller::createApplicationRegistryKeys() {
     success = insertRegistryKey(REGISTRY_PATH, "UninstallString", uninstallPath);
     success = insertRegistryKey(REGISTRY_PATH, "DisplayVersion", std::string(LAUNCHER_BUILD_VERSION));
     success = insertRegistryKey(REGISTRY_PATH, "DisplayIcon", applicationExe);
-    success = insertRegistryKey(REGISTRY_PATH, "Publisher", "High Fidelity");
+    success = insertRegistryKey(REGISTRY_PATH, "Publisher", "Vircadia");
 
     auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 

--- a/launchers/qt/src/main.cpp
+++ b/launchers/qt/src/main.cpp
@@ -31,7 +31,7 @@ bool hasSuffix(const std::string& path, const std::string& suffix) {
 
 int main(int argc, char *argv[]) {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-    QCoreApplication::setOrganizationName("High Fidelity");
+    QCoreApplication::setOrganizationName("Vircadia");
     QCoreApplication::setApplicationName("HQ Launcher");
 
     Q_INIT_RESOURCE(resources);

--- a/launchers/win32/LauncherManager.cpp
+++ b/launchers/win32/LauncherManager.cpp
@@ -310,7 +310,7 @@ BOOL LauncherManager::getAndCreatePaths(PathType type, CString& outPath) {
                 outPath += DIRECTORY_NAME_INTERFACE;
             } else if (type == PathType::Content_Directory) {
                 outPath += DIRECTORY_NAME_CONTENT;
-            } 
+            }
             return (CreateDirectory(outPath, NULL) || ERROR_ALREADY_EXISTS == GetLastError());
         }
     }
@@ -377,7 +377,7 @@ BOOL LauncherManager::createConfigJSON() {
     return TRUE;
 }
 
-LauncherUtils::ResponseError LauncherManager::readConfigJSON(CString& version, CString& domain, 
+LauncherUtils::ResponseError LauncherManager::readConfigJSON(CString& version, CString& domain,
                                                              CString& content, bool& loggedIn, CString& organizationBuildTag) {
     CString configPath;
     getAndCreatePaths(PathType::Interface_Directory, configPath);
@@ -388,7 +388,7 @@ LauncherUtils::ResponseError LauncherManager::readConfigJSON(CString& version, C
     }
     Json::Value config;
     configFile >> config;
-    if (config["version"].isString() && 
+    if (config["version"].isString() &&
         config["domain"].isString() &&
         config["content"].isString()) {
         loggedIn = config["loggedIn"].asBool();
@@ -446,7 +446,7 @@ LauncherUtils::ResponseError LauncherManager::readOrganizationJSON(const CString
     CString url = _T("/organizations/") + hash + _T(".json");
     LauncherUtils::ResponseError error = LauncherUtils::makeHTTPCall(getHttpUserAgent(),
                                                                      true, L"orgs.highfidelity.com", url,
-                                                                     contentTypeJson, CStringA(), 
+                                                                     contentTypeJson, CStringA(),
                                                                      response, false);
     if (error != LauncherUtils::ResponseError::NoError) {
         return error;
@@ -557,7 +557,7 @@ void LauncherManager::onMostRecentBuildsReceived(const CString& response, Launch
                 addToLog(_T("Already running most recent build. Launching interface.exe"));
             } else {
                 addToLog(_T("Updating the launcher was not allowed --noUpdate"));
-            }            
+            }
             if (isInstalled) {
                 addToLog(_T("Installed version: ") + currentVersion);
                 if (!newInterfaceVersion) {
@@ -576,7 +576,7 @@ void LauncherManager::onMostRecentBuildsReceived(const CString& response, Launch
             }
         }
         _shouldWait = FALSE;
-        
+
     } else {
         setFailed(true);
         CString msg;
@@ -587,7 +587,7 @@ void LauncherManager::onMostRecentBuildsReceived(const CString& response, Launch
     }
 }
 
-LauncherUtils::ResponseError LauncherManager::getAccessTokenForCredentials(const CString& username, 
+LauncherUtils::ResponseError LauncherManager::getAccessTokenForCredentials(const CString& username,
                                                                            const CString& password) {
     CStringA post = "grant_type=password&username=";
     post += username;
@@ -599,9 +599,9 @@ LauncherUtils::ResponseError LauncherManager::getAccessTokenForCredentials(const
     CString response;
     LauncherUtils::ResponseError error = LauncherUtils::makeHTTPCall(getHttpUserAgent(),
                                                                      true,
-                                                                     L"metaverse.highfidelity.com", 
+                                                                     L"metaverse.highfidelity.com",
                                                                      L"/oauth/token",
-                                                                     contentTypeText, post, 
+                                                                     contentTypeText, post,
                                                                      response, true);
     if (error != LauncherUtils::ResponseError::NoError) {
         return error;
@@ -629,7 +629,7 @@ BOOL LauncherManager::createApplicationRegistryKeys(int size) {
     success = LauncherUtils::insertRegistryKey(REGISTRY_PATH, "UninstallString", uninstallPath);
     success = LauncherUtils::insertRegistryKey(REGISTRY_PATH, "DisplayVersion", LauncherUtils::cStringToStd(_latestVersion));
     success = LauncherUtils::insertRegistryKey(REGISTRY_PATH, "DisplayIcon", applicationExe);
-    success = LauncherUtils::insertRegistryKey(REGISTRY_PATH, "Publisher", "High Fidelity");
+    success = LauncherUtils::insertRegistryKey(REGISTRY_PATH, "Publisher", "Vircadia");
     success = LauncherUtils::insertRegistryKey(REGISTRY_PATH, "InstallDate", LauncherUtils::cStringToStd(CTime::GetCurrentTime().Format("%Y%m%d")));
     success = LauncherUtils::insertRegistryKey(REGISTRY_PATH, "EstimatedSize", (DWORD)size);
     success = LauncherUtils::insertRegistryKey(REGISTRY_PATH, "NoModify", (DWORD)1);
@@ -686,9 +686,9 @@ BOOL LauncherManager::extractApplication() {
         updateProgress(ProcessType::UnzipApplication, max(progress, 0.0f));
     };
     _currentProcess = ProcessType::UnzipApplication;
-    BOOL success = LauncherUtils::unzipFileOnThread(ProcessType::UnzipApplication, 
+    BOOL success = LauncherUtils::unzipFileOnThread(ProcessType::UnzipApplication,
                                                     LauncherUtils::cStringToStd(_applicationZipPath),
-                                                    LauncherUtils::cStringToStd(installPath), 
+                                                    LauncherUtils::cStringToStd(installPath),
                                                     onExtractFinished, onProgress);
     if (success) {
         addToLog(_T("Created thread for unzipping application."));
@@ -737,7 +737,7 @@ void LauncherManager::restartNewLauncher() {
         continueAction = ContinueActionOnStart::ContinueUpdate;
     } else if (_keepLoggingIn) {
         continueAction = ContinueActionOnStart::ContinueLogIn;
-    }    
+    }
     CStringW params;
     params.Format(_T(" --restart --noUpdate --continueAction %s"), getContinueActionParam(continueAction));
     LauncherUtils::launchApplication(_tempLauncherPath, params.GetBuffer());

--- a/screenshare/packager.js
+++ b/screenshare/packager.js
@@ -26,8 +26,8 @@ if (osType == "Darwin") {
     options["app-bundle-id"] = "com.highfidelity.hifi-screenshare";
 } else if (osType == "Windows_NT") {
     options["version-string"] = {
-        CompanyName: "High Fidelity, Inc.",
-        FileDescription: "High Fidelity Screenshare",
+        CompanyName: "Vircadia",
+        FileDescription: "Vircadia Screenshare",
         ProductName: NAME,
         OriginalFilename: NAME + ".exe"
     }
@@ -47,4 +47,3 @@ packager(options)
         console.error("There was an error writing the packaged console: " + error.message);
         process.exit(1);
     });
-    

--- a/tools/nitpick/src/TestRunnerDesktop.cpp
+++ b/tools/nitpick/src/TestRunnerDesktop.cpp
@@ -3,6 +3,7 @@
 //
 //  Created by Nissim Hadar on 1 Sept 2018.
 //  Copyright 2013 High Fidelity, Inc.
+//  Copyright 2020 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -46,7 +47,7 @@ TestRunnerDesktop::TestRunnerDesktop(
 
     _installerThread = new QThread();
     _installerWorker = new InstallerWorker();
-        
+
     _installerWorker->moveToThread(_installerThread);
     _installerThread->start();
     connect(this, SIGNAL(startInstaller()), _installerWorker, SLOT(runCommand()));
@@ -77,9 +78,9 @@ void TestRunnerDesktop::setWorkingFolderAndEnableControls() {
     setWorkingFolder(_workingFolderLabel);
 
 #ifdef Q_OS_WIN
-    _installationFolder = _workingFolder + "/High Fidelity";
+    _installationFolder = _workingFolder + "/Vircadia";
 #elif defined Q_OS_MAC
-    _installationFolder = _workingFolder + "/High_Fidelity";
+    _installationFolder = _workingFolder + "/Vircadia";
 #endif
 
     nitpick->enableRunTabControls();
@@ -87,11 +88,11 @@ void TestRunnerDesktop::setWorkingFolderAndEnableControls() {
     _timer = new QTimer(this);
     connect(_timer, SIGNAL(timeout()), this, SLOT(checkTime()));
     _timer->start(30 * 1000);  //time specified in ms
-    
+
 #ifdef Q_OS_MAC
     // Create MAC shell scripts
     QFile script;
-    
+
     // This script waits for a process to start
     script.setFileName(_workingFolder + "/waitForStart.sh");
     if (!script.open(QIODevice::WriteOnly | QIODevice::Text)) {
@@ -99,7 +100,7 @@ void TestRunnerDesktop::setWorkingFolderAndEnableControls() {
                               "Could not open 'waitForStart.sh'");
         exit(-1);
     }
-    
+
     script.write("#!/bin/sh\n\n");
     script.write("PROCESS=\"$1\"\n");
     script.write("until (pgrep -x $PROCESS >nul)\n");
@@ -118,7 +119,7 @@ void TestRunnerDesktop::setWorkingFolderAndEnableControls() {
                               "Could not open 'waitForFinish.sh'");
         exit(-1);
     }
-    
+
     script.write("#!/bin/sh\n\n");
     script.write("PROCESS=\"$1\"\n");
     script.write("while (pgrep -x $PROCESS >nul)\n");
@@ -129,7 +130,7 @@ void TestRunnerDesktop::setWorkingFolderAndEnableControls() {
     script.write("echo \"$1\" \"finished\"\n");
     script.close();
     script.setPermissions(QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner);
-    
+
     // Create an AppleScript to resize Interface.  This is needed so that snapshots taken
     // with the primary camera will be the correct size.
     // This will be run from a normal shell script
@@ -139,7 +140,7 @@ void TestRunnerDesktop::setWorkingFolderAndEnableControls() {
                               "Could not open 'setInterfaceSizeAndPosition.scpt'");
         exit(-1);
     }
-    
+
     script.write("set width to 960\n");
     script.write("set height to 540\n");
     script.write("set x to 100\n");
@@ -155,7 +156,7 @@ void TestRunnerDesktop::setWorkingFolderAndEnableControls() {
                               "Could not open 'setInterfaceSizeAndPosition.sh'");
         exit(-1);
     }
-    
+
     script.write("#!/bin/sh\n\n");
     script.write("echo resizing interface\n");
     script.write(("osascript " + _workingFolder + "/setInterfaceSizeAndPosition.scpt\n").toStdString().c_str());
@@ -193,7 +194,7 @@ void TestRunnerDesktop::downloadComplete() {
         // Download of Build XML has completed
         buildXMLDownloaded = true;
 
-        // Download the High Fidelity installer
+        // Download the Vircadia installer
         QStringList urls;
         QStringList filenames;
         if (_runLatest->isChecked()) {
@@ -251,23 +252,23 @@ void TestRunnerDesktop::runInstaller() {
                               "Could not open 'install_app.sh'");
         exit(-1);
     }
-    
+
     if (!QDir().exists(_installationFolder)) {
         QDir().mkdir(_installationFolder);
     }
-    
-    // This script installs High Fidelity.  It is run as "yes | install_app.sh... so "yes" is killed at the end
+
+    // This script installs Vircadia.  It is run as "yes | install_app.sh... so "yes" is killed at the end
     script.write("#!/bin/sh\n\n");
     script.write("VOLUME=`hdiutil attach \"$1\" | grep Volumes | awk '{print $3}'`\n");
-    
-    QString folderName {"High Fidelity"};
+
+    QString folderName {"Vircadia"};
     if (!_runLatest->isChecked()) {
         folderName += QString(" - ") + getPRNumberFromURL(_url->text());
     }
 
     script.write((QString("cp -Rf \"$VOLUME/") + folderName + "/interface.app\" \"" + _workingFolder + "/High_Fidelity/\"\n").toStdString().c_str());
     script.write((QString("cp -Rf \"$VOLUME/") + folderName + "/Sandbox.app\" \""   + _workingFolder + "/High_Fidelity/\"\n").toStdString().c_str());
-    
+
     script.write("hdiutil detach \"$VOLUME\"\n");
     script.write("killall yes\n");
     script.close();
@@ -303,10 +304,10 @@ void TestRunnerDesktop::verifyInstallationSucceeded() {
     if (!interfaceExe.exists() || !assignmentClientExe.exists() || !domainServerExe.exists()) {
         if (_runLatest->isChecked()) {
             // On Windows, the reason is probably that UAC has blocked the installation.  This is treated as a critical error
-            QMessageBox::critical(0, "Installation of High Fidelity has failed", "Please verify that UAC has been disabled");
+            QMessageBox::critical(0, "Installation of Vircadia has failed", "Please verify that UAC has been disabled");
             exit(-1);
         } else {
-            QMessageBox::critical(0, "Installation of High Fidelity not found", "Please verify that working folder contains a proper installation");
+            QMessageBox::critical(0, "Installation of vircadia not found", "Please verify that working folder contains a proper installation");
         }
     }
 #endif
@@ -320,10 +321,10 @@ void TestRunnerDesktop::saveExistingHighFidelityAppDataFolder() {
     dataDirectory = QDir::homePath() + "/Library/Application Support";
 #endif
     if (_runLatest->isChecked()) {
-        _appDataFolder = dataDirectory + "/High Fidelity";
+        _appDataFolder = dataDirectory + "/Vircadia";
     } else {
         // We are running a PR build
-        _appDataFolder = dataDirectory + "/High Fidelity - " + getPRNumberFromURL(_url->text());
+        _appDataFolder = dataDirectory + "/Vircadia - " + getPRNumberFromURL(_url->text());
     }
 
     _savedAppDataFolder = dataDirectory + "/" + UNIQUE_FOLDER_NAME;
@@ -419,13 +420,13 @@ void TestRunnerDesktop::killProcesses() {
     }
 #elif defined Q_OS_MAC
     QString commandLine;
-    
+
     commandLine = QString("killall interface") + "; " + _workingFolder +"/waitForFinish.sh interface";
     system(commandLine.toStdString().c_str());
-    
+
     commandLine = QString("killall Sandbox") + "; " + _workingFolder +"/waitForFinish.sh Sandbox";
     system(commandLine.toStdString().c_str());
-    
+
     commandLine = QString("killall Console") + "; " + _workingFolder +"/waitForFinish.sh Console";
     system(commandLine.toStdString().c_str());
 #endif
@@ -433,7 +434,7 @@ void TestRunnerDesktop::killProcesses() {
 
 void TestRunnerDesktop::startLocalServerProcesses() {
     QString commandLine;
-    
+
 #ifdef Q_OS_WIN
     commandLine =
         "start \"domain-server.exe\" \"" + QDir::toNativeSeparators(_installationFolder) + "\\domain-server.exe\"";
@@ -501,9 +502,9 @@ void TestRunnerDesktop::runInterfaceWithTestScript() {
                               "Could not open 'runInterfaceTests.sh'");
         exit(-1);
     }
-    
+
     script.write("#!/bin/sh\n\n");
-    
+
     // First, run script to delete any entities in test area
     commandLine =
     "open -W \"" +_installationFolder + "/interface.app\" --args" +
@@ -511,9 +512,9 @@ void TestRunnerDesktop::runInterfaceWithTestScript() {
     " --no-updater" +
     " --no-login-suggestion"
     " --testScript " + deleteScript + " quitWhenFinished\n";
-    
+
     script.write(commandLine.toStdString().c_str());
-    
+
     // On The Mac, we need to resize Interface.  The Interface window opens a few seconds after the process
     // has started.
     // Before starting interface, start a process that will resize interface 10s after it opens
@@ -539,7 +540,7 @@ void TestRunnerDesktop::runInterfaceWithTestScript() {
 
     emit startInterface();
 #endif
-    
+
     // Helpful for debugging
     appendLog(commandLine);
 }
@@ -555,7 +556,7 @@ void TestRunnerDesktop::interfaceExecutionComplete() {
 
     evaluateResults();
 
-    // The High Fidelity AppData folder will be restored after evaluation has completed
+    // The Vircadia AppData folder will be restored after evaluation has completed
 }
 
 void TestRunnerDesktop::evaluateResults() {


### PR DESCRIPTION
This PR changes some strings, folders and comments from "High Fidelity" to "Vircadia".
While most of the rebranded components seem unused to me, this PR should fix the Interface showing up as "High Fidelity" on macOS.

I will try building and running this on macOS.
EDIT: my macOS broke so I will not try building and running on macOS..