### PR TITLE
Delay taking snapshot further at low render rates

### DIFF
--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -474,9 +474,10 @@ function takeSnapshot() {
             volume: 1.0
         });
         HMD.closeTablet();
+        var DOUBLE_RENDER_TIME_TO_MS = 2000; // If rendering is bogged down, allow double the render time to close the tablet.
         Script.setTimeout(function () {
             Window.takeSnapshot(false, includeAnimated, 1.91);
-        }, SNAPSHOT_DELAY);
+        }, Math.max(SNAPSHOT_DELAY, DOUBLE_RENDER_TIME_TO_MS / Rates.render ));
     }, FINISH_SOUND_DELAY);
     UserActivityLogger.logAction("snaphshot_taken", { location: location.href });
 }


### PR DESCRIPTION
This should fix occurrences of the Snapshot app dialog appearing in snapshots, which can occasionally happen at present.

This is hard to test because the problem is hard to reproduce. It can be artificially reproduced by setting, say, the `ECO_PROFILE` game rate targets to 1Hz in RefreshRateManager.cpp and removing the timeout for `Window.takeSnapShot()` in snapshot.js.