### PR TITLE
Fix avatar not displaying when recording is re-loaded

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -615,7 +615,7 @@ void Agent::setIsAvatar(bool isAvatar) {
             delete _avatarQueryTimer;
             _avatarQueryTimer = nullptr;
 
-            // Clear the skeleton model so thatk if agent is set to an avatar again the skeleton model is (re)loaded.
+            // Clear the skeleton model so that if agent is set to an avatar again the skeleton model is (re)loaded.
             auto scriptedAvatar = DependencyManager::get<ScriptableAvatar>();
             scriptedAvatar->setSkeletonModelURL(QUrl());
 

--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -615,6 +615,10 @@ void Agent::setIsAvatar(bool isAvatar) {
             delete _avatarQueryTimer;
             _avatarQueryTimer = nullptr;
 
+            // Clear the skeleton model so thatk if agent is set to an avatar again the skeleton model is (re)loaded.
+            auto scriptedAvatar = DependencyManager::get<ScriptableAvatar>();
+            scriptedAvatar->setSkeletonModelURL(QUrl());
+
             // The avatar mixer never times out a connection (e.g., based on identity or data packets)
             // but rather keeps avatars in its list as long as "connected". As a result, clients timeout
             // when we stop sending identity, but then get woken up again by the mixer itself, which sends


### PR DESCRIPTION
Repro the issue - https://github.com/kasenvr/project-athena/issues/518 - with current Vircadia release then test that this PR fixes the issue.

Use both the Interface and the Sandbox from this PR while testing.
You can use the playRecordingAC.js AC script from the URL mentioned in the dialog, i.e.: https://cdn.vircadia.com/community-apps/applications/record/playRecordingAC.js

Test with a single AC script instance:
- Test one recording - loading, unloading, and loading it again. The avatar should be displayed both times.
- Test two separate recordings that have different avatars - loading one, unloading it, loading the other. The correct avatar should be displayed each time.
