### PR TITLE
Fix display of FBX models with only one color for vertices

### DIFF
--- a/libraries/fbx/src/FBXSerializer_Mesh.cpp
+++ b/libraries/fbx/src/FBXSerializer_Mesh.cpp
@@ -127,7 +127,7 @@ void appendIndex(MeshData& data, QVector<int>& indices, int index, bool deduplic
 
 
     glm::vec4 color;
-    bool hasColors = (data.colors.size() > 1);
+    bool hasColors = (data.colors.size() > 0);
     if (hasColors) {
         int colorIndex = data.colorsByVertex ? vertexIndex : index;
         if (data.colorIndices.isEmpty()) {    


### PR DESCRIPTION
Fixes issue: https://github.com/kasenvr/project-athena/issues/294

