### PR TITLE
Increase graphics settings' resolution scale item maximum to 2.0

### DIFF
--- a/interface/resources/qml/hifi/dialogs/graphics/GraphicsSettings.qml
+++ b/interface/resources/qml/hifi/dialogs/graphics/GraphicsSettings.qml
@@ -336,8 +336,8 @@ Item {
                         height: parent.height
                         colorScheme: hifi.colorSchemes.dark
                         minimumValue: 0.25
-                        maximumValue: 1.0
-                        stepSize: 0.02
+                        maximumValue: 2.0
+                        stepSize: 0.05
                         value: Render.viewportResolutionScale
                         live: true
 


### PR DESCRIPTION
Settings > Graphics dialog, "Resolution Scale" slider now goes up to 2.0 (instead of 1.0).

Notes:
- This slider is adjustable if the graphics setting is set to "Custom".
- Custom graphics settings are not save between program runs. https://github.com/kasenvr/project-athena/issues/35