### PR TITLE
Domain login groups and "not authorized on domain"

### DIFF
--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -600,15 +600,15 @@ bool DomainGatekeeper::verifyUserSignature(const QString& username,
                 return true;
 
             } else {
-                // we only send back a LoginError if this wasn't an "optimistic" key
+                // we only send back a LoginErrorMetaverse if this wasn't an "optimistic" key
                 // (a key that we hoped would work but is probably stale)
 
                 if (!senderSockAddr.isNull() && !isOptimisticKey) {
-                    qDebug() << "Error decrypting username signature for" << username << "- denying connection.";
+                    qDebug() << "Error decrypting metaverse username signature for" << username << "- denying connection.";
                     sendConnectionDeniedPacket("Error decrypting username signature.", senderSockAddr,
-                        DomainHandler::ConnectionRefusedReason::LoginError);
+                        DomainHandler::ConnectionRefusedReason::LoginErrorMetaverse);
                 } else if (!senderSockAddr.isNull()) {
-                    qDebug() << "Error decrypting username signature for" << username << "with optimisitic key -"
+                    qDebug() << "Error decrypting metaverse username signature for" << username << "with optimistic key -"
                         << "re-requesting public key and delaying connection";
                 }
 
@@ -622,7 +622,7 @@ bool DomainGatekeeper::verifyUserSignature(const QString& username,
             if (!senderSockAddr.isNull()) {
                 qDebug() << "Couldn't convert data to RSA key for" << username << "- denying connection.";
                 sendConnectionDeniedPacket("Couldn't convert data to RSA key.", senderSockAddr,
-                    DomainHandler::ConnectionRefusedReason::LoginError);
+                    DomainHandler::ConnectionRefusedReason::LoginErrorMetaverse);
             }
         }
     } else {

--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -155,8 +155,8 @@ void DomainGatekeeper::processConnectRequestPacket(QSharedPointer<ReceivedMessag
 }
 
 NodePermissions DomainGatekeeper::setPermissionsForUser(bool isLocalUser, QString verifiedUsername,
-                                                        QString verifiedAuxliaryUsername, 
-                                                        QStringList verifiedAuxiliaryUserGroups,
+                                                        QString verifiedDomainUserName, 
+                                                        QStringList verifiedDomainUserGroups,
                                                         const QHostAddress& senderAddress, const QString& hardwareAddress,
                                                         const QUuid& machineFingerprint) {
     NodePermissions userPerms;
@@ -172,19 +172,19 @@ NodePermissions DomainGatekeeper::setPermissionsForUser(bool isLocalUser, QStrin
 
     // If this user is a known member of an externally-hosted group, give them the implied permissions.
     // Do before processing verifiedUsername in case user is logged into the metaverse and is a member of a blacklist group.
-    if (!verifiedAuxliaryUsername.isEmpty() && !verifiedAuxiliaryUserGroups.isEmpty()) {
-        foreach (QString group, verifiedAuxiliaryUserGroups) {
+    if (!verifiedDomainUserName.isEmpty() && !verifiedDomainUserGroups.isEmpty()) {
+        foreach (QString group, verifiedDomainUserGroups) {
             if (_server->_settingsManager.getAllKnownGroupNames().contains(group)) {
                 userPerms |= _server->_settingsManager.getPermissionsForGroup(group, QUuid());
 //#ifdef WANT_DEBUG
-                qDebug() << "|  user-permissions: auxiliary user " << verifiedAuxliaryUsername << "is in group:" << group << "so:" << userPerms;
+                qDebug() << "|  user-permissions: domain user " << verifiedDomainUserName << "is in group:" << group << "so:" << userPerms;
 //#endif
 
             }
         }
 
-        userPerms.setVerifiedAuxiliaryUserName(verifiedAuxliaryUsername);
-        userPerms.setVerifiedAuxiliaryUserGroups(verifiedAuxiliaryUserGroups);
+        userPerms.setVerifiedDomainUserName(verifiedDomainUserName);
+        userPerms.setVerifiedDomainUserGroups(verifiedDomainUserGroups);
     }
 
     if (verifiedUsername.isEmpty()) {
@@ -307,8 +307,8 @@ void DomainGatekeeper::updateNodePermissions() {
         // the id and the username in NodePermissions will often be the same, but id is set before
         // authentication and verifiedUsername is only set once they user's key has been confirmed.
         QString verifiedUsername = node->getPermissions().getVerifiedUserName();
-        QString verifiedAuxiliaryUsername = node->getPermissions().getVerifiedAuxiliaryUserName();
-        QStringList verifiedAuxiliaryUserGroups = node->getPermissions().getVerifiedAuxiliaryUserGroups();
+        QString verifiedDomainUserName = node->getPermissions().getVerifiedDomainUserName();
+        QStringList verifiedDomainUserGroups = node->getPermissions().getVerifiedDomainUserGroups();
         NodePermissions userPerms(NodePermissionsKey(verifiedUsername, 0));
 
         if (node->getPermissions().isAssignment) {
@@ -343,8 +343,8 @@ void DomainGatekeeper::updateNodePermissions() {
                                sendingAddress == QHostAddress::LocalHost);
             }
 
-            userPerms = setPermissionsForUser(isLocalUser, verifiedUsername, verifiedAuxiliaryUsername, 
-                                              verifiedAuxiliaryUserGroups,  connectingAddr.getAddress(), 
+            userPerms = setPermissionsForUser(isLocalUser, verifiedUsername, verifiedDomainUserName, 
+                                              verifiedDomainUserGroups, connectingAddr.getAddress(), 
                                               hardwareAddress, machineFingerprint);
         }
 

--- a/domain-server/src/DomainGatekeeper.h
+++ b/domain-server/src/DomainGatekeeper.h
@@ -126,8 +126,8 @@ private:
     QSet<QString> _domainOwnerFriends; // keep track of friends of the domain owner
     QSet<QString> _inFlightGroupMembershipsRequests; // keep track of which we've already asked for
 
-    NodePermissions setPermissionsForUser(bool isLocalUser, QString verifiedUsername, QString verifiedAuxliaryUsername,
-                                          QStringList verifiedAuxiliaryUserGroups, const QHostAddress& senderAddress,
+    NodePermissions setPermissionsForUser(bool isLocalUser, QString verifiedUsername, QString verifiedDomainUsername,
+                                          QStringList verifiedDomainUserGroups, const QHostAddress& senderAddress,
                                           const QString& hardwareAddress, const QUuid& machineFingerprint);
 
     void getGroupMemberships(const QString& username);

--- a/domain-server/src/DomainGatekeeper.h
+++ b/domain-server/src/DomainGatekeeper.h
@@ -76,11 +76,17 @@ private:
                                                       const PendingAssignedNodeData& pendingAssignment);
     SharedNodePointer processAgentConnectRequest(const NodeConnectionData& nodeConnection,
                                                  const QString& username,
-                                                 const QByteArray& usernameSignature);
+                                                 const QByteArray& usernameSignature,
+                                                 const QString& domainUsername,
+                                                 const QByteArray& domainUsernameSignature);
     SharedNodePointer addVerifiedNodeFromConnectRequest(const NodeConnectionData& nodeConnection);
     
     bool verifyUserSignature(const QString& username, const QByteArray& usernameSignature,
                              const HifiSockAddr& senderSockAddr);
+    
+    bool verifyDomainUserSignature(const QString& domainUsername, const QByteArray& domainUsernameSignature,
+                                   const HifiSockAddr& senderSockAddr);
+
     bool isWithinMaxCapacity();
     
     bool shouldAllowConnectionFromNode(const QString& username, const QByteArray& usernameSignature,
@@ -127,6 +133,8 @@ private:
     void getGroupMemberships(const QString& username);
     // void getIsGroupMember(const QString& username, const QUuid groupID);
     void getDomainOwnerFriendsList();
+
+    bool domainHasLogin();
 
     // Local ID management.
     void initLocalIDManagement();

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -492,7 +492,7 @@ void DomainHandler::processICEResponsePacket(QSharedPointer<ReceivedMessage> mes
 
 bool DomainHandler::reasonSuggestsMetaverseLogin(ConnectionRefusedReason reasonCode) {
     switch (reasonCode) {
-        case ConnectionRefusedReason::LoginError:
+        case ConnectionRefusedReason::LoginErrorMetaverse:
         case ConnectionRefusedReason::NotAuthorizedMetaverse:
             return true;
 
@@ -507,7 +507,7 @@ bool DomainHandler::reasonSuggestsMetaverseLogin(ConnectionRefusedReason reasonC
 
 bool DomainHandler::reasonSuggestsDomainLogin(ConnectionRefusedReason reasonCode) {
     switch (reasonCode) {
-        case ConnectionRefusedReason::LoginError:
+        case ConnectionRefusedReason::LoginErrorDomain:
         case ConnectionRefusedReason::NotAuthorizedDomain:
             return true;
 

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -177,9 +177,9 @@ public:
      *       <td>You could not be logged into the domain.</td>
      *     </tr>
      *     <tr>
-     *       <td><strong>NotAuthorized</strong></td>
+     *       <td><strong>NotAuthorizedMetaverse</strong></td>
      *       <td><code>3</code></td>
-     *       <td>You are not authorized to connect to the domain.</td>
+     *       <td>You are not authorized to connect to the domain per your metaverse login.</td>
      *     </tr>
      *     <tr>
      *       <td><strong>TooManyUsers</strong></td>
@@ -191,6 +191,11 @@ public:
      *       <td><code>5</code></td>
      *       <td>Connecting to the domain timed out.</td>
      *     </tr>
+     *     <tr>
+     *       <td><strong>NotAuthorizedDomain</strong></td>
+     *       <td><code>6</code></td>
+     *       <td>You are not authorized to connect to the domain per your domain login.</td>
+     *     </tr>
      *   </tbody>
      * </table>
      * @typedef {number} Window.ConnectionRefusedReason
@@ -200,9 +205,9 @@ public:
         ProtocolMismatch,
         LoginError,
         NotAuthorizedMetaverse,
-        NotAuthorizedDomain,
         TooManyUsers,
-        TimedOut
+        TimedOut,
+        NotAuthorizedDomain
     };
 
 public slots:

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -172,9 +172,9 @@ public:
      *       <td>The communications protocols of the domain and your Interface are not the same.</td>
      *     </tr>
      *     <tr>
-     *       <td><strong>LoginError</strong></td>
+     *       <td><strong>LoginErrorMetaverse</strong></td>
      *       <td><code>2</code></td>
-     *       <td>You could not be logged into the domain.</td>
+     *       <td>You could not be logged into the domain per your metaverse login.</td>
      *     </tr>
      *     <tr>
      *       <td><strong>NotAuthorizedMetaverse</strong></td>
@@ -192,6 +192,11 @@ public:
      *       <td>Connecting to the domain timed out.</td>
      *     </tr>
      *     <tr>
+     *       <td><strong>LoginErrorDomain</strong></td>
+     *       <td><code>2</code></td>
+     *       <td>You could not be logged into the domain per your domain login.</td>
+     *     </tr>
+     *     <tr>
      *       <td><strong>NotAuthorizedDomain</strong></td>
      *       <td><code>6</code></td>
      *       <td>You are not authorized to connect to the domain per your domain login.</td>
@@ -203,10 +208,11 @@ public:
     enum class ConnectionRefusedReason : uint8_t {
         Unknown,
         ProtocolMismatch,
-        LoginError,
+        LoginErrorMetaverse,
         NotAuthorizedMetaverse,
         TooManyUsers,
         TimedOut,
+        LoginErrorDomain,
         NotAuthorizedDomain
     };
 

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -474,6 +474,22 @@ void NodeList::sendDomainServerCheckIn() {
             if (requiresUsernameSignature && accountManager->getAccountInfo().hasPrivateKey()) {
                 const QByteArray& usernameSignature = accountManager->getAccountInfo().getUsernameSignature(connectionToken);
                 packetStream << usernameSignature;
+            } else {
+                packetStream << QString("");  // Placeholder in case have domainUsername.
+            }
+        } else {
+            packetStream << QString("");  // Placeholder in case have domainUsername.
+        }
+
+        // ####### TODO: Send domain username and signature if domain has these and aren't logged in.
+        // #######       If get into difficulties, could perhaps send domain's username and signature instead of metaverse.
+        bool domainLoginIsConnected = false;
+        if (!domainLoginIsConnected) {
+            if (true) {
+                packetStream << QString("a@b.c");
+                if (true) {
+                    packetStream << QString("signature");
+                }
             }
         }
 

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -379,6 +379,7 @@ void NodeList::sendDomainServerCheckIn() {
         if (domainPacketType == PacketType::DomainConnectRequest) {
 
 #if (PR_BUILD || DEV_BUILD)
+            // #######
             if (_shouldSendNewerVersion) {
                 domainPacket->setVersion(versionForPacketType(domainPacketType) + 1);
             }

--- a/libraries/networking/src/NodePermissions.h
+++ b/libraries/networking/src/NodePermissions.h
@@ -51,10 +51,10 @@ public:
     void setVerifiedUserName(QString userName) { _verifiedUserName = userName.toLower(); }
     const QString& getVerifiedUserName() const { return _verifiedUserName; }
 
-    void setVerifiedAuxiliaryUserName(QString userName) { _verifiedAuxiliaryUserName = userName.toLower(); }
-    const QString& getVerifiedAuxiliaryUserName() const { return _verifiedAuxiliaryUserName; }
-    void setVerifiedAuxiliaryUserGroups(QStringList userGroups) { _verifiedAuxiliaryUserGroups = userGroups; }
-    const QStringList& getVerifiedAuxiliaryUserGroups() const { return _verifiedAuxiliaryUserGroups; }
+    void setVerifiedDomainUserName(QString userName) { _verifiedDomainUserName = userName.toLower(); }
+    const QString& getVerifiedDomainUserName() const { return _verifiedDomainUserName; }
+    void setVerifiedDomainUserGroups(QStringList userGroups) { _verifiedDomainUserGroups = userGroups; }
+    const QStringList& getVerifiedDomainUserGroups() const { return _verifiedDomainUserGroups; }
 
     void setGroupID(QUuid groupID) { _groupID = groupID; if (!groupID.isNull()) { _groupIDSet = true; }}
     QUuid getGroupID() const { return _groupID; }
@@ -104,8 +104,8 @@ protected:
     QString _id;
     QUuid _rankID { QUuid() }; // 0 unless this is for a group
     QString _verifiedUserName;
-    QString _verifiedAuxiliaryUserName;
-    QStringList _verifiedAuxiliaryUserGroups;
+    QString _verifiedDomainUserName;
+    QStringList _verifiedDomainUserGroups;
 
     bool _groupIDSet { false };
     QUuid _groupID;


### PR DESCRIPTION
- Distinguishes not logged into metaverse from not logged into domain.
- Applies permissions for groups (user roles) from domain login.
- Generates "not authorized on domain" condition (with stubs for related OAuth2 code).