### PR TITLE
Initial version of automatic texture memory size

### DIFF
--- a/libraries/gl/src/gl/Config.cpp
+++ b/libraries/gl/src/gl/Config.cpp
@@ -74,6 +74,10 @@ static void* getGlProcessAddress(const char *namez) {
 
 #else
 
+
+typedef Bool ( *PFNGLXQUERYCURRENTRENDERERINTEGERMESAPROC) (int attribute, unsigned int *value);
+PFNGLXQUERYCURRENTRENDERERINTEGERMESAPROC QueryCurrentRendererIntegerMESA;
+
 static void* getGlProcessAddress(const char *namez) {
     return (void*)glXGetProcAddressARB((const GLubyte*)namez);
 }
@@ -90,6 +94,10 @@ void gl::initModuleGl() {
         wglGetSwapIntervalEXT = (PFNWGLGETSWAPINTERVALEXTPROC)getGlProcessAddress("wglGetSwapIntervalEXT");
         wglChoosePixelFormatARB = (PFNWGLCHOOSEPIXELFORMATARBPROC)getGlProcessAddress("wglChoosePixelFormatARB");
         wglCreateContextAttribsARB = (PFNWGLCREATECONTEXTATTRIBSARBPROC)getGlProcessAddress("wglCreateContextAttribsARB");
+#endif
+
+#if defined(Q_OS_LINUX)
+        QueryCurrentRendererIntegerMESA = (PFNGLXQUERYCURRENTRENDERERINTEGERMESAPROC)getGlProcessAddress("glXQueryCurrentRendererIntegerMESA");
 #endif
 
 #if defined(USE_GLES)
@@ -123,4 +131,15 @@ void gl::setSwapInterval(int interval) {
 #else
     Q_UNUSED(interval);
 #endif
+}
+
+bool gl::queryCurrentRendererIntegerMESA(int attr, unsigned int *value) {
+    #if defined(Q_OS_LINUX)
+    if (QueryCurrentRendererIntegerMESA) {
+        return QueryCurrentRendererIntegerMESA(attr, value);
+    }
+    #endif
+
+    *value = 0;
+    return false;
 }

--- a/libraries/gl/src/gl/Config.cpp
+++ b/libraries/gl/src/gl/Config.cpp
@@ -75,7 +75,7 @@ static void* getGlProcessAddress(const char *namez) {
 #else
 
 
-typedef Bool ( *PFNGLXQUERYCURRENTRENDERERINTEGERMESAPROC) (int attribute, unsigned int *value);
+typedef Bool (*PFNGLXQUERYCURRENTRENDERERINTEGERMESAPROC) (int attribute, unsigned int *value);
 PFNGLXQUERYCURRENTRENDERERINTEGERMESAPROC QueryCurrentRendererIntegerMESA;
 
 static void* getGlProcessAddress(const char *namez) {

--- a/libraries/gl/src/gl/Config.h
+++ b/libraries/gl/src/gl/Config.h
@@ -52,7 +52,7 @@ namespace gl {
     void initModuleGl();
     int getSwapInterval();
     void setSwapInterval(int swapInterval);
-    bool  queryCurrentRendererIntegerMESA(int attr, unsigned int *value);
+    bool queryCurrentRendererIntegerMESA(int attr, unsigned int *value);
 }
 
 #endif // hifi_gpu_GPUConfig_h

--- a/libraries/gl/src/gl/Config.h
+++ b/libraries/gl/src/gl/Config.h
@@ -52,6 +52,7 @@ namespace gl {
     void initModuleGl();
     int getSwapInterval();
     void setSwapInterval(int swapInterval);
+    bool  queryCurrentRendererIntegerMESA(int attr, unsigned int *value);
 }
 
 #endif // hifi_gpu_GPUConfig_h

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.cpp
@@ -160,7 +160,6 @@ void GLBackend::init() {
             qCDebug(gpugllogging) << "GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX: " << GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX;
             qCDebug(gpugllogging) << "GPU_MEMORY_INFO_TOTAL_AVAILABLE_MEMORY_NVX: " << GPU_MEMORY_INFO_TOTAL_AVAILABLE_MEMORY_NVX;
             qCDebug(gpugllogging) << "GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX: " << GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX;
-            qCDebug(gpugllogging) << "sz: " << sizeof(_totalMemory);
 
             _totalMemory = GPU_MEMORY_INFO_TOTAL_AVAILABLE_MEMORY_NVX * BYTES_PER_KIB;
             _dedicatedMemory = GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX * BYTES_PER_KIB;
@@ -237,10 +236,14 @@ size_t GLBackend::getAvailableMemory() {
 
 bool GLBackend::availableMemoryKnown() {
     switch( _videoCard ) {
-        case NVIDIA: return true;
-        case ATI: return true;
-        case MESA: return false;
-        case Unknown: return false;
+        case NVIDIA:
+            return true;
+        case ATI:
+            return true;
+        case MESA:
+            return false;
+        case Unknown:
+            return false;
     }
 
     return false;

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
@@ -70,6 +70,7 @@ public:
     enum VideoCardType {
         ATI,
         NVIDIA,
+        Intel,
         Unknown
     };
 
@@ -101,13 +102,13 @@ public:
     static GLint TEXTURE_FREE_MEMORY_ATI;
 
 
-    static size_t _total_memory;
-    static size_t _dedicated_memory;
-    static VideoCardType _video_card;
+    static size_t _totalMemory;
+    static size_t _dedicatedMemory;
+    static VideoCardType _videoCard;
 
 
-    static size_t getTotalMemory() { return _total_memory; }
-    static size_t getDedicatedMemory() { return _dedicated_memory; }
+    static size_t getTotalMemory() { return _totalMemory; }
+    static size_t getDedicatedMemory() { return _dedicatedMemory; }
 
     static size_t getAvailableMemory();
 

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
@@ -67,6 +67,12 @@ protected:
     GLBackend();
 
 public:
+    enum VideoCardType {
+        ATI,
+        NVIDIA,
+        Unknown
+    };
+
 #if defined(USE_GLES)
     // https://www.khronos.org/registry/OpenGL-Refpages/es3/html/glGet.xhtml
     static const GLint MIN_REQUIRED_TEXTURE_IMAGE_UNITS = 16;
@@ -89,6 +95,24 @@ public:
     static GLint MAX_COMBINED_TEXTURE_IMAGE_UNITS;
     static GLint MAX_UNIFORM_BLOCK_SIZE;
     static GLint UNIFORM_BUFFER_OFFSET_ALIGNMENT;
+    static GLint GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX;
+    static GLint GPU_MEMORY_INFO_TOTAL_AVAILABLE_MEMORY_NVX;
+    static GLint GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX;
+    static GLint TEXTURE_FREE_MEMORY_ATI;
+
+
+    static size_t _total_memory;
+    static size_t _dedicated_memory;
+    static VideoCardType _video_card;
+
+
+    static size_t getTotalMemory() { return _total_memory; }
+    static size_t getDedicatedMemory() { return _dedicated_memory; }
+
+    static size_t getAvailableMemory();
+
+
+
 
     virtual ~GLBackend();
 

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
@@ -111,6 +111,7 @@ public:
     static size_t getDedicatedMemory() { return _dedicatedMemory; }
 
     static size_t getAvailableMemory();
+    static bool availableMemoryKnown();
 
 
 

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
@@ -70,7 +70,7 @@ public:
     enum VideoCardType {
         ATI,
         NVIDIA,
-        Intel,
+        MESA,
         Unknown
     };
 

--- a/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
@@ -223,7 +223,7 @@ void GLTextureTransferEngineDefault::updateMemoryPressure() {
         idealMemoryAllocation += texture->evalTotalSize();
         // Track how much we're actually using
         totalVariableMemoryAllocation += gltexture->size();
-        if (vartexture->canDemote()) {
+        if (!gltexture->_gpuObject.getImportant() && vartexture->canDemote()) {
             canDemote |= true;
         }
         if (vartexture->canPromote()) {
@@ -503,7 +503,7 @@ void GLTextureTransferEngineDefault::processDemotes(size_t reliefRequired, const
     for (const auto& texture : strongTextures) {
         GLTexture* gltexture = Backend::getGPUObject<GLTexture>(*texture);
         GLVariableAllocationSupport* vargltexture = dynamic_cast<GLVariableAllocationSupport*>(gltexture);
-        if (vargltexture->canDemote()) {
+        if (!gltexture->_gpuObject.getImportant() && vargltexture->canDemote()) {
             demoteQueue.push({ texture, (float)gltexture->size() });
         }
     }

--- a/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
@@ -239,13 +239,16 @@ void GLTextureTransferEngineDefault::updateMemoryPressure() {
     float pressure = 0;
 
     if (useAvailableGlMemory) {
-        float totalMem = GLBackend::getTotalMemory();
-        float availMem = GLBackend::getAvailableMemory() - AUTO_RESERVE_TEXTURE_MEMORY;
-        if (availMem < 0) {
+        size_t totalMem = GLBackend::getTotalMemory();
+        size_t availMem = GLBackend::getAvailableMemory();
+
+        if (availMem >= AUTO_RESERVE_TEXTURE_MEMORY) {
+            availMem -= AUTO_RESERVE_TEXTURE_MEMORY;
+        } else {
             availMem = 0;
         }
 
-        pressure = (totalMem - availMem) / totalMem;
+        pressure = ((float)totalMem - (float)availMem) / (float)totalMem;
     } else {
         pressure = (float)totalVariableMemoryAllocation / (float)allowedMemoryAllocation;
     }

--- a/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
@@ -191,7 +191,7 @@ void GLTextureTransferEngineDefault::updateMemoryPressure() {
     if (0 == allowedMemoryAllocation) {
         // Automatic allocation
 
-        if ( GLBackend::availableMemoryKnown() ) {
+        if (GLBackend::availableMemoryKnown()) {
             // If we know how much is free, then we use that
             useAvailableGlMemory = true;
         } else {
@@ -199,7 +199,7 @@ void GLTextureTransferEngineDefault::updateMemoryPressure() {
             // and hope it works.
             allowedMemoryAllocation = GLBackend::getTotalMemory() * MAX_AUTO_FRACTION_OF_TOTAL_MEMORY;
 
-            if ( 0 == allowedMemoryAllocation ) {
+            if (0 == allowedMemoryAllocation) {
                 // Last resort, if we failed to detect
                 allowedMemoryAllocation = DEFAULT_ALLOWED_TEXTURE_MEMORY;
             }
@@ -238,14 +238,14 @@ void GLTextureTransferEngineDefault::updateMemoryPressure() {
     size_t unallocated = idealMemoryAllocation - totalVariableMemoryAllocation;
     float pressure = 0;
 
-    if ( useAvailableGlMemory ) {
-        float total_mem = GLBackend::getTotalMemory();
-        float avail_mem = GLBackend::getAvailableMemory() - AUTO_RESERVE_TEXTURE_MEMORY;
-        if ( avail_mem < 0 ) {
-            avail_mem = 0;
+    if (useAvailableGlMemory) {
+        float totalMem = GLBackend::getTotalMemory();
+        float availMem = GLBackend::getAvailableMemory() - AUTO_RESERVE_TEXTURE_MEMORY;
+        if (availMem < 0) {
+            availMem = 0;
         }
 
-        pressure = (total_mem - avail_mem) / total_mem;
+        pressure = (totalMem - availMem) / totalMem;
     } else {
         pressure = (float)totalVariableMemoryAllocation / (float)allowedMemoryAllocation;
     }

--- a/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
@@ -185,7 +185,11 @@ void GLTextureTransferEngineDefault::updateMemoryPressure() {
 
     size_t allowedMemoryAllocation = gpu::Texture::getAllowedGPUMemoryUsage();
     if (0 == allowedMemoryAllocation) {
-        allowedMemoryAllocation = DEFAULT_ALLOWED_TEXTURE_MEMORY;
+        allowedMemoryAllocation = GLBackend::getTotalMemory();
+        if ( 0 == allowedMemoryAllocation ) {
+            // Last resort, if we failed to detect
+            allowedMemoryAllocation = DEFAULT_ALLOWED_TEXTURE_MEMORY;
+        }
     }
 
     // Clear any defunct textures (weak pointers that no longer have a valid texture)

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -571,6 +571,9 @@ public:
     void setExternalRecycler(const ExternalRecycler& recycler);
     ExternalRecycler getExternalRecycler() const;
 
+    bool getImportant() const { return _important; }
+    void setImportant(bool important) { _important = important; }
+
     const GPUObjectPointer gpuObject {};
 
     ExternalUpdates getUpdates() const;
@@ -632,6 +635,7 @@ protected:
     bool _autoGenerateMips = false;
     bool _isIrradianceValid = false;
     bool _defined = false;
+    bool _important = false;
    
     static TexturePointer create(TextureUsageType usageType, Type type, const Element& texelFormat, uint16 width, uint16 height, uint16 depth, uint16 numSamples, uint16 numSlices, uint16 numMips, const Sampler& sampler);
 

--- a/libraries/render-utils/src/text/Font.cpp
+++ b/libraries/render-utils/src/text/Font.cpp
@@ -260,6 +260,7 @@ void Font::read(QIODevice& in) {
                                       gpu::Sampler(gpu::Sampler::FILTER_MIN_POINT_MAG_LINEAR));
     _texture->setStoredMipFormat(formatMip);
     _texture->assignStoredMip(0, image.sizeInBytes(), image.constBits());
+    _texture->setImportant(true);
 }
 
 void Font::setupGPU() {


### PR DESCRIPTION
This fixes the automatic texture memory size option.

In the original code, "auto" simply hard-codes texture size to 1 GB, and isn't "auto" whatsoever.

This PR implements 3 policies, with the one we use depending on what we can know:

* If we know how much VRAM is free (NVIDIA and ATI report this), then we query that. The code will then use available VRAM, leaving some amount (currently hardcoded as 64MB).
* If we don't know how much VRAM is free, but we do know how much there is in total, we set the limit to a percentage of that. This  happens on Intel. Currently the max use is hardcoded to 80%. The assumption here is that this is a low-spec machine, and unlikely to be running anything else at the same time, so we just need to leave some margin for system use.
* If we don't know anything, fallback to the old method, which just goes with 1GB. That seems reasonable considering my ancient work laptop that's absolutely not fit for running Vircadia reports 1.5 GB.


The first case needs testing. It's not a fixed memory limit, but tries to use whatever memory is free, so it's also going to be influenced by anything else on the system that allocates VRAM.

This fixes bug #30 