### PR TITLE
Support blendshapes on glTF models without needing FST files

### DIFF
--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -1675,5 +1675,152 @@ HFMModel::Pointer FBXSerializer::read(const hifi::ByteArray& data, const hifi::V
 
     // FBXSerializer's mapping parameter supports the bool "deduplicateIndices," which is passed into FBXSerializer::extractMesh as "deduplicate"
 
-    return HFMModel::Pointer(extractHFMModel(mapping, url.toString()));
+    auto hfmModel = extractHFMModel(mapping, url.toString());
+
+    //hfmDebugDump(*hfmModel);
+
+    return HFMModel::Pointer(hfmModel);
+}
+
+void FBXSerializer::hfmDebugDump(const HFMModel& hfmModel) {
+    qCDebug(modelformat) << "---------------- hfmModel ----------------";
+    qCDebug(modelformat) << "  originalURL =" << hfmModel.originalURL;
+
+    qCDebug(modelformat) << "  hasSkeletonJoints =" << hfmModel.hasSkeletonJoints;
+    qCDebug(modelformat) << "  offset =" << hfmModel.offset;
+
+    qCDebug(modelformat) << "  neckPivot = " << hfmModel.neckPivot;
+
+    qCDebug(modelformat) << "  bindExtents.size() = " << hfmModel.bindExtents.size();
+    qCDebug(modelformat) << "  meshExtents.size() = " << hfmModel.meshExtents.size();
+
+    qCDebug(modelformat) << "  jointIndices.size() =" << hfmModel.jointIndices.size();
+    qCDebug(modelformat) << "  joints.count() =" << hfmModel.joints.count();
+    qCDebug(modelformat) << "---------------- Meshes ----------------";
+    qCDebug(modelformat) << "  meshes.count() =" << hfmModel.meshes.count();
+    qCDebug(modelformat) << "  blendshapeChannelNames = " << hfmModel.blendshapeChannelNames;
+    foreach(HFMMesh mesh, hfmModel.meshes) {
+        qCDebug(modelformat) << "\n";
+        qCDebug(modelformat) << "    meshpointer =" << mesh._mesh.get();
+        qCDebug(modelformat) << "    meshindex =" << mesh.meshIndex;
+        qCDebug(modelformat) << "    vertices.count() =" << mesh.vertices.size();
+        qCDebug(modelformat) << "    colors.count() =" << mesh.colors.count();
+        qCDebug(modelformat) << "    normals.count() =" << mesh.normals.size();
+        qCDebug(modelformat) << "    tangents.count() =" << mesh.tangents.size();
+        qCDebug(modelformat) << "    colors.count() =" << mesh.colors.count();
+        qCDebug(modelformat) << "    texCoords.count() =" << mesh.texCoords.count();
+        qCDebug(modelformat) << "    texCoords1.count() =" << mesh.texCoords1.count();
+        qCDebug(modelformat) << "    clusterIndices.count() =" << mesh.clusterIndices.count();
+        qCDebug(modelformat) << "    clusterWeights.count() =" << mesh.clusterWeights.count();
+        qCDebug(modelformat) << "    modelTransform =" << mesh.modelTransform;
+        qCDebug(modelformat) << "    parts.count() =" << mesh.parts.count();
+        qCDebug(modelformat) << "---------------- Meshes (blendshapes)--------";
+        foreach(HFMBlendshape bshape, mesh.blendshapes) {
+            qCDebug(modelformat) << "\n";
+            qCDebug(modelformat) << "    bshape.indices.count() =" << bshape.indices.count();
+            qCDebug(modelformat) << "    bshape.vertices.count() =" << bshape.vertices.count();
+            qCDebug(modelformat) << "    bshape.normals.count() =" << bshape.normals.count();
+            qCDebug(modelformat) << "\n";
+        }
+        qCDebug(modelformat) << "---------------- Meshes (meshparts)--------";
+        foreach(HFMMeshPart meshPart, mesh.parts) {
+            qCDebug(modelformat) << "\n";
+            qCDebug(modelformat) << "        quadIndices.count() =" << meshPart.quadIndices.count();
+            qCDebug(modelformat) << "        triangleIndices.count() =" << meshPart.triangleIndices.count();
+            qCDebug(modelformat) << "        materialID =" << meshPart.materialID;
+            qCDebug(modelformat) << "\n";
+
+        }
+        qCDebug(modelformat) << "---------------- Meshes (clusters)--------";
+        qCDebug(modelformat) << "    clusters.count() =" << mesh.clusters.count();
+        foreach(HFMCluster cluster, mesh.clusters) {
+            qCDebug(modelformat) << "\n";
+            qCDebug(modelformat) << "        jointIndex =" << cluster.jointIndex;
+            qCDebug(modelformat) << "        inverseBindMatrix =" << cluster.inverseBindMatrix;
+            qCDebug(modelformat) << "\n";
+        }
+        qCDebug(modelformat) << "\n";
+    }
+    qCDebug(modelformat) << "---------------- AnimationFrames ----------------";
+    foreach(HFMAnimationFrame anim, hfmModel.animationFrames) {
+        qCDebug(modelformat) << "  anim.translations = " << anim.translations;
+        qCDebug(modelformat) << "  anim.rotations = " << anim.rotations;
+    }
+    QList<int> mitomona_keys = hfmModel.meshIndicesToModelNames.keys();
+    foreach(int key, mitomona_keys) {
+        qCDebug(modelformat) << "    meshIndicesToModelNames key =" << key << "  val =" << hfmModel.meshIndicesToModelNames[key];
+    }
+
+    qCDebug(modelformat) << "---------------- Materials ----------------";
+
+    foreach(HFMMaterial mat, hfmModel.materials) {
+        qCDebug(modelformat) << "\n";
+        qCDebug(modelformat) << "  mat.materialID =" << mat.materialID;
+        qCDebug(modelformat) << "  diffuseColor =" << mat.diffuseColor;
+        qCDebug(modelformat) << "  diffuseFactor =" << mat.diffuseFactor;
+        qCDebug(modelformat) << "  specularColor =" << mat.specularColor;
+        qCDebug(modelformat) << "  specularFactor =" << mat.specularFactor;
+        qCDebug(modelformat) << "  emissiveColor =" << mat.emissiveColor;
+        qCDebug(modelformat) << "  emissiveFactor =" << mat.emissiveFactor;
+        qCDebug(modelformat) << "  shininess =" << mat.shininess;
+        qCDebug(modelformat) << "  opacity =" << mat.opacity;
+        qCDebug(modelformat) << "  metallic =" << mat.metallic;
+        qCDebug(modelformat) << "  roughness =" << mat.roughness;
+        qCDebug(modelformat) << "  emissiveIntensity =" << mat.emissiveIntensity;
+        qCDebug(modelformat) << "  ambientFactor =" << mat.ambientFactor;
+
+        qCDebug(modelformat) << "  materialID =" << mat.materialID;
+        qCDebug(modelformat) << "  name =" << mat.name;
+        qCDebug(modelformat) << "  shadingModel =" << mat.shadingModel;
+        qCDebug(modelformat) << "  _material =" << mat._material.get();
+
+        qCDebug(modelformat) << "  normalTexture =" << mat.normalTexture.filename;
+        qCDebug(modelformat) << "  albedoTexture =" << mat.albedoTexture.filename;
+        qCDebug(modelformat) << "  opacityTexture =" << mat.opacityTexture.filename;
+
+        qCDebug(modelformat) << "  lightmapParams =" << mat.lightmapParams;
+
+        qCDebug(modelformat) << "  isPBSMaterial =" << mat.isPBSMaterial;
+        qCDebug(modelformat) << "  useNormalMap =" << mat.useNormalMap;
+        qCDebug(modelformat) << "  useAlbedoMap =" << mat.useAlbedoMap;
+        qCDebug(modelformat) << "  useOpacityMap =" << mat.useOpacityMap;
+        qCDebug(modelformat) << "  useRoughnessMap =" << mat.useRoughnessMap;
+        qCDebug(modelformat) << "  useSpecularMap =" << mat.useSpecularMap;
+        qCDebug(modelformat) << "  useMetallicMap =" << mat.useMetallicMap;
+        qCDebug(modelformat) << "  useEmissiveMap =" << mat.useEmissiveMap;
+        qCDebug(modelformat) << "  useOcclusionMap =" << mat.useOcclusionMap;
+        qCDebug(modelformat) << "\n";
+    }
+
+    qCDebug(modelformat) << "---------------- Joints ----------------";
+
+    foreach(HFMJoint joint, hfmModel.joints) {
+        qCDebug(modelformat) << "\n";
+        qCDebug(modelformat) << "    shapeInfo.avgPoint =" << joint.shapeInfo.avgPoint;
+        qCDebug(modelformat) << "    shapeInfo.debugLines =" << joint.shapeInfo.debugLines;
+        qCDebug(modelformat) << "    shapeInfo.dots =" << joint.shapeInfo.dots;
+        qCDebug(modelformat) << "    shapeInfo.points =" << joint.shapeInfo.points;
+
+        qCDebug(modelformat) << "    parentIndex" << joint.parentIndex;
+        qCDebug(modelformat) << "    distanceToParent" << joint.distanceToParent;
+        qCDebug(modelformat) << "    translation" << joint.translation;
+        qCDebug(modelformat) << "    preTransform" << joint.preTransform;
+        qCDebug(modelformat) << "    preRotation" << joint.preRotation;
+        qCDebug(modelformat) << "    rotation" << joint.rotation;
+        qCDebug(modelformat) << "    postRotation" << joint.postRotation;
+        qCDebug(modelformat) << "    postTransform" << joint.postTransform;
+        qCDebug(modelformat) << "    transform" << joint.transform;
+        qCDebug(modelformat) << "    rotationMin" << joint.rotationMin;
+        qCDebug(modelformat) << "    rotationMax" << joint.rotationMax;
+        qCDebug(modelformat) << "    inverseDefaultRotation" << joint.inverseDefaultRotation;
+        qCDebug(modelformat) << "    inverseBindRotation" << joint.inverseBindRotation;
+        qCDebug(modelformat) << "    bindTransform" << joint.bindTransform;
+        qCDebug(modelformat) << "    name" << joint.name;
+        qCDebug(modelformat) << "    isSkeletonJoint" << joint.isSkeletonJoint;
+        qCDebug(modelformat) << "    bindTransformFoundInCluster" << joint.hasGeometricOffset;
+        qCDebug(modelformat) << "    bindTransformFoundInCluster" << joint.geometricTranslation;
+        qCDebug(modelformat) << "    bindTransformFoundInCluster" << joint.geometricRotation;
+        qCDebug(modelformat) << "    bindTransformFoundInCluster" << joint.geometricScaling;
+        qCDebug(modelformat) << "\n";
+    }
 }

--- a/libraries/fbx/src/FBXSerializer.h
+++ b/libraries/fbx/src/FBXSerializer.h
@@ -170,6 +170,8 @@ public:
     static QVector<int> getIntVector(const FBXNode& node);
     static QVector<float> getFloatVector(const FBXNode& node);
     static QVector<double> getDoubleVector(const FBXNode& node);
+
+    void hfmDebugDump(const HFMModel& hfmModel);
 };
 
 #endif // hifi_FBXSerializer_h

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -1686,7 +1686,9 @@ HFMModel::Pointer GLTFSerializer::read(const hifi::ByteArray& data, const hifi::
         HFMModel& hfmModel = *hfmModelPtr;
         buildGeometry(hfmModel, mapping, _url);
 
-        //hfmDebugDump(data);
+        //hfmDebugDump(hfmModel);
+        //glTFDebugDump();
+
         return hfmModelPtr;
     } else {
         qCDebug(modelformat) << "Error parsing GLTF file.";
@@ -2037,6 +2039,8 @@ void GLTFSerializer::retriangulate(const QVector<int>& inIndices, const QVector<
 }
 
 void GLTFSerializer::glTFDebugDump() {
+    qCDebug(modelformat) << "---------------- GLTF Model ----------------";
+
     qCDebug(modelformat) << "---------------- Nodes ----------------";
     for (GLTFNode node : _file.nodes) {
         if (node.defined["mesh"]) {
@@ -2070,6 +2074,8 @@ void GLTFSerializer::glTFDebugDump() {
 
 void GLTFSerializer::hfmDebugDump(const HFMModel& hfmModel) {
     qCDebug(modelformat) << "---------------- hfmModel ----------------";
+    qCDebug(modelformat) << "  originalURL =" << hfmModel.originalURL;
+
     qCDebug(modelformat) << "  hasSkeletonJoints =" << hfmModel.hasSkeletonJoints;
     qCDebug(modelformat) << "  offset =" << hfmModel.offset;
 
@@ -2207,9 +2213,6 @@ void GLTFSerializer::hfmDebugDump(const HFMModel& hfmModel) {
         qCDebug(modelformat) << "    bindTransformFoundInCluster" << joint.geometricScaling;
         qCDebug(modelformat) << "\n";
     }
-
-    qCDebug(modelformat) << "---------------- GLTF Model ----------------";
-    glTFDebugDump();
 
     qCDebug(modelformat) << "\n";
 }

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -540,8 +540,7 @@ bool GLTFSerializer::addMesh(const QJsonObject& object) {
                 }
 
                 QJsonArray jsTargets;
-                if (getObjectArrayVal(jsPrimitive, "targets", jsTargets, primitive.defined))
-                {
+                if (getObjectArrayVal(jsPrimitive, "targets", jsTargets, primitive.defined)) {
                     foreach(const QJsonValue & tar, jsTargets) {
                         if (tar.isObject()) {
                             QJsonObject jsTarget = tar.toObject();
@@ -555,7 +554,7 @@ bool GLTFSerializer::addMesh(const QJsonObject& object) {
                             primitive.targets.push_back(target);
                         }
                     }
-                }                
+                }
                 mesh.primitives.push_back(primitive);
             }
         }
@@ -830,6 +829,8 @@ void GLTFSerializer::generateTargetData(int index, float weight, QVector<glm::ve
 }
 
 bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& mapping, const hifi::URL& url) {
+    hfmModel.originalURL = url.toString();
+
     int numNodes = _file.nodes.size();
 
     //Build dependencies
@@ -1539,7 +1540,9 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
 
                 // populate the texture coordinates if they don't exist
                 if (mesh.texCoords.size() == 0 && !hfmModel.hasSkeletonJoints) {
-                    for (int i = 0; i < part.triangleIndices.size(); ++i) { mesh.texCoords.push_back(glm::vec2(0.0, 1.0)); }
+                    for (int i = 0; i < part.triangleIndices.size(); ++i) { 
+                        mesh.texCoords.push_back(glm::vec2(0.0, 1.0));
+                    }
                 }
 
                 // Build morph targets (blend shapes)


### PR DESCRIPTION
Blendshapes were already supported in glTF files provided you use an FST file to map them. This PR adds support for blendshapes in glTF files without needing an FST file, provided you use the standard blendshape names.
