### PR TITLE
Add "About" JavaScript API and platform string

### DIFF
--- a/interface/resources/qml/hifi/dialogs/TabletAboutDialog.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAboutDialog.qml
@@ -3,6 +3,7 @@
 //
 //  Created by David Rowe on 18 Apr 2017
 //  Copyright 2017 High Fidelity, Inc.
+//  Copyright 2020 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -33,12 +34,12 @@ Rectangle {
             anchors.left: parent.left
             anchors.leftMargin: 70
             RalewayRegular {
-                text: "Build " + HiFiAbout.buildVersion
+                text: "Build " + About.buildVersion
                 size: 16
                 color: "white"
             }
             RalewayRegular {
-                text: "Released " + HiFiAbout.buildDate
+                text: "Released " + About.buildDate
                 size: 16
                 color: "white"
             }
@@ -56,7 +57,7 @@ Rectangle {
             text: "<a href=\"https://github.com/kasenvr/project-athena\">Vircadia Github</a>."
             size: 20
             onLinkActivated: {
-                HiFiAbout.openUrl("https:/github.com/kasenvr/project-athena");
+                About.openUrl("https:/github.com/kasenvr/project-athena");
             }
 
         }
@@ -70,13 +71,13 @@ Rectangle {
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
-                        HiFiAbout.openUrl("https://www.qt.io/");
+                        About.openUrl("https://www.qt.io/");
                     }
                 }
             }
             RalewayRegular {
                 color: "white"
-                text: "Built using Qt " + HiFiAbout.qtVersion
+                text: "Built using Qt " + About.qtVersion
                 size: 12
                 anchors.verticalCenter: parent.verticalCenter
             }
@@ -102,7 +103,7 @@ Rectangle {
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
-                        HiFiAbout.openUrl("http://opus-codec.org/");
+                        About.openUrl("http://opus-codec.org/");
                     }
                 }
             }
@@ -131,7 +132,7 @@ Rectangle {
             text: "Distributed under the <a href=\"http://www.apache.org/licenses/LICENSE-2.0.html\">Apache License, Version 2.0.</a>."
             size: 14
             onLinkActivated: {
-                HiFiAbout.openUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
+                About.openUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
             }
         }
     }

--- a/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
@@ -894,7 +894,7 @@ Flickable {
                     hoverEnabled: true
                     onEntered: privacyPolicyUnderline.visible = true;
                     onExited: privacyPolicyUnderline.visible = false;
-                    onClicked: HiFiAbout.openUrl("https://vircadia.com/privacy-policy");
+                    onClicked: About.openUrl("https://vircadia.com/privacy-policy");
                 }
             }
 

--- a/interface/src/AboutUtil.h
+++ b/interface/src/AboutUtil.h
@@ -4,6 +4,7 @@
 //
 //  Created by Vlad Stelmahovsky on 15/5/2018.
 //  Copyright 2018 High Fidelity, Inc.
+//  Copyright 2020 Vircadia Contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -16,10 +17,10 @@
 #include <QObject>
 
 /**jsdoc
- * The <code>HifiAbout</code> API provides information about the version of Interface that is currently running. It also
- * has the functionality to open a web page in an Interface browser window.
+ * The <code>About</code> API provides information about the version of Interface that is currently running. It also has the
+ * functionality to open a web page in an Interface browser window.
  *
- * @namespace HifiAbout
+ * @namespace About
  *
  * @hifi-interface
  * @hifi-client-entity
@@ -30,9 +31,28 @@
  * @property {string} qtVersion - The Qt version used in Interface that is currently running. <em>Read-only.</em>
  *
  * @example <caption>Report build information for the version of Interface currently running.</caption>
- * print("HiFi build date: " + HifiAbout.buildDate);  // Returns the build date of the version of Interface currently running on your machine.
- * print("HiFi version: " + HifiAbout.buildVersion);  // Returns the build version of Interface currently running on your machine.
- * print("Qt version: " + HifiAbout.qtVersion);  // Returns the Qt version details of the version of Interface currently running on your machine.
+ * print("Interface build date: " + About.buildDate);
+ * print("Interface version: " + About.buildVersion);
+ * print("Qt version: " + About.qtVersion);
+ */
+
+ /**jsdoc
+ * The <code>HifiAbout</code> API provides information about the version of Interface that is currently running. It also
+ * has the functionality to open a web page in an Interface browser window.
+ *
+ * @namespace HifiAbout
+ *
+ * @hifi-interface
+ * @hifi-client-entity
+ * @hifi-avatar
+ *
+ * @deprecated This API is deprecated and will be removed. Use the {@link About} API instead.
+ *
+ * @property {string} buildDate - The build date of Interface that is currently running. <em>Read-only.</em>
+ * @property {string} buildVersion - The build version of Interface that is currently running. <em>Read-only.</em>
+ * @property {string} qtVersion - The Qt version used in Interface that is currently running. <em>Read-only.</em>
+ *
+ * @borrows About.openUrl as openUrl
  */
 
 class AboutUtil : public QObject {
@@ -53,7 +73,7 @@ public slots:
 
     /**jsdoc
      * Display a web page in an Interface browser window.
-     * @function HifiAbout.openUrl
+     * @function About.openUrl
      * @param {string} url - The URL of the web page you want to view in Interface.
      */
     void openUrl(const QString &url) const;

--- a/interface/src/AboutUtil.h
+++ b/interface/src/AboutUtil.h
@@ -26,11 +26,14 @@
  * @hifi-client-entity
  * @hifi-avatar
  *
+ * @property {string} platform - The name of the Interface platform running, e,g., <code>"Vircadia"</code> for the Vircadia.
+ *     <em>Read-only.</em>
  * @property {string} buildDate - The build date of Interface that is currently running. <em>Read-only.</em>
  * @property {string} buildVersion - The build version of Interface that is currently running. <em>Read-only.</em>
  * @property {string} qtVersion - The Qt version used in Interface that is currently running. <em>Read-only.</em>
  *
- * @example <caption>Report build information for the version of Interface currently running.</caption>
+ * @example <caption>Report information on the version of Interface currently running.</caption>
+ * print("Interface platform: " + About.platform);
  * print("Interface build date: " + About.buildDate);
  * print("Interface version: " + About.buildVersion);
  * print("Qt version: " + About.qtVersion);
@@ -48,6 +51,8 @@
  *
  * @deprecated This API is deprecated and will be removed. Use the {@link About} API instead.
  *
+ * @property {string} platform - The name of the Interface platform running, e,g., <code>"Vircadia"</code> for the Vircadia.
+ *     <em>Read-only.</em>
  * @property {string} buildDate - The build date of Interface that is currently running. <em>Read-only.</em>
  * @property {string} buildVersion - The build version of Interface that is currently running. <em>Read-only.</em>
  * @property {string} qtVersion - The Qt version used in Interface that is currently running. <em>Read-only.</em>
@@ -58,6 +63,7 @@
 class AboutUtil : public QObject {
     Q_OBJECT
 
+    Q_PROPERTY(QString platform READ getPlatformName CONSTANT)
     Q_PROPERTY(QString buildDate READ getBuildDate CONSTANT)
     Q_PROPERTY(QString buildVersion READ getBuildVersion CONSTANT)
     Q_PROPERTY(QString qtVersion READ getQtVersion CONSTANT)
@@ -65,6 +71,7 @@ public:
     static AboutUtil* getInstance();
     ~AboutUtil() {}
 
+    QString getPlatformName() const { return "Vircadia"; }
     QString getBuildDate() const;
     QString getBuildVersion() const;
     QString getQtVersion() const;

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3512,7 +3512,8 @@ void Application::onDesktopRootContextCreated(QQmlContext* surfaceContext) {
     surfaceContext->setContextProperty("Selection", DependencyManager::get<SelectionScriptingInterface>().data());
     surfaceContext->setContextProperty("ContextOverlay", DependencyManager::get<ContextOverlayInterface>().data());
     surfaceContext->setContextProperty("WalletScriptingInterface", DependencyManager::get<WalletScriptingInterface>().data());
-    surfaceContext->setContextProperty("HiFiAbout", AboutUtil::getInstance());
+    surfaceContext->setContextProperty("About", AboutUtil::getInstance());
+    surfaceContext->setContextProperty("HiFiAbout", AboutUtil::getInstance());  // Deprecated
     surfaceContext->setContextProperty("ResourceRequestObserver", DependencyManager::get<ResourceRequestObserver>().data());
 
     if (auto steamClient = PluginManager::getInstance()->getSteamClientPlugin()) {
@@ -3623,7 +3624,8 @@ void Application::setupQmlSurface(QQmlContext* surfaceContext, bool setAdditiona
         surfaceContext->setContextProperty("Pointers", DependencyManager::get<PointerScriptingInterface>().data());
         surfaceContext->setContextProperty("Window", DependencyManager::get<WindowScriptingInterface>().data());
         surfaceContext->setContextProperty("Reticle", qApp->getApplicationCompositor().getReticleInterface());
-        surfaceContext->setContextProperty("HiFiAbout", AboutUtil::getInstance());
+        surfaceContext->setContextProperty("About", AboutUtil::getInstance());
+        surfaceContext->setContextProperty("HiFiAbout", AboutUtil::getInstance());  // Deprecated.
         surfaceContext->setContextProperty("WalletScriptingInterface", DependencyManager::get<WalletScriptingInterface>().data());
         surfaceContext->setContextProperty("ResourceRequestObserver", DependencyManager::get<ResourceRequestObserver>().data());
         surfaceContext->setContextProperty("PlatformInfo", PlatformInfoScriptingInterface::getInstance());
@@ -7520,7 +7522,8 @@ void Application::registerScriptEngineWithApplicationServices(const ScriptEngine
     scriptEngine->registerGlobalObject("ContextOverlay", DependencyManager::get<ContextOverlayInterface>().data());
     scriptEngine->registerGlobalObject("WalletScriptingInterface", DependencyManager::get<WalletScriptingInterface>().data());
     scriptEngine->registerGlobalObject("AddressManager", DependencyManager::get<AddressManager>().data());
-    scriptEngine->registerGlobalObject("HifiAbout", AboutUtil::getInstance());
+    scriptEngine->registerGlobalObject("About", AboutUtil::getInstance());
+    scriptEngine->registerGlobalObject("HifiAbout", AboutUtil::getInstance());  // Deprecated.
     scriptEngine->registerGlobalObject("ResourceRequestObserver", DependencyManager::get<ResourceRequestObserver>().data());
 
     registerInteractiveWindowMetaType(scriptEngine.data());

--- a/scripts/system/interstitialPage.js
+++ b/scripts/system/interstitialPage.js
@@ -369,7 +369,7 @@
         }
     }
 
-    var THE_PLACE = (HifiAbout.buildVersion === "dev") ? "hifi://TheSpot-dev" : "hifi://TheSpot";
+    var THE_PLACE = (About.buildVersion === "dev") ? "hifi://TheSpot-dev" : "hifi://TheSpot";
     function clickedOnOverlay(overlayID, event) {
         if (loadingToTheSpotHoverID === overlayID) {
             location.handleLookupString(THE_PLACE);


### PR DESCRIPTION
This duplicates the `HifiAbout` API and adds an `About.platform` property that returns `"Vircadia"`.

The old `HiFAbout` API is still provided but it is labelled as "deprecated" in the API docs.