### PR TITLE
Add --get-temp-name to domain-server invocation in creation of Docker

### DIFF
--- a/pkg-scripts/docker-vircadia-supervisor.conf
+++ b/pkg-scripts/docker-vircadia-supervisor.conf
@@ -7,7 +7,7 @@ logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
 
 [program:domain-server]
-command=/opt/vircadia/domain-server
+command=/opt/vircadia/domain-server --get-temp-name
 autorestart=unexpected
 directory=/opt/vircadia
 


### PR DESCRIPTION
Add --get-temp-name to domain-server invocation in creation of Docker domain-server image in pkg-scripts. This parameter is required by the domain-server so it will fetch a temporary domain name if it is not configured.