### PR TITLE
Don't display domain log-in items unless relevant

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1352,10 +1352,10 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     connect(accountManager.data(), &AccountManager::usernameChanged, this, &Application::updateWindowTitle);
 
     auto domainAccountManager = DependencyManager::get<DomainAccountManager>();
-    connect(domainAccountManager.data(), &DomainAccountManager::authRequired, dialogsManager.data(), 
-        &DialogsManager::showDomainLoginDialog);
-    connect(domainAccountManager.data(), &DomainAccountManager::loginComplete, this, 
-        &Application::updateWindowTitle);
+    connect(domainAccountManager.data(), &DomainAccountManager::authRequired,
+        dialogsManager.data(), &DialogsManager::showDomainLoginDialog);
+    connect(domainAccountManager.data(), &DomainAccountManager::authRequired, this, &Application::updateWindowTitle);
+    connect(domainAccountManager.data(), &DomainAccountManager::loginComplete, this, &Application::updateWindowTitle);
     // ####### TODO: Connect any other signals from domainAccountManager.
 
     // use our MyAvatar position and quat for address manager path
@@ -7084,6 +7084,7 @@ void Application::updateWindowTitle() const {
     auto domainAccountManager = DependencyManager::get<DomainAccountManager>();
     auto isInErrorState = nodeList->getDomainHandler().isInErrorState();
     bool isMetaverseLoggedIn = accountManager->isLoggedIn();
+    bool hasDomainLogIn = domainAccountManager->hasLogIn();
     bool isDomainLoggedIn = domainAccountManager->isLoggedIn();
     QString authedDomain = domainAccountManager->getAuthedDomain();
 
@@ -7115,20 +7116,23 @@ void Application::updateWindowTitle() const {
 
     QString metaverseDetails;
     if (isMetaverseLoggedIn) {
-        metaverseDetails = "Metaverse: Logged in as " + metaverseUsername;
+        metaverseDetails = " (Metaverse: Logged in as " + metaverseUsername + ")";
     } else {
-        metaverseDetails = "Metaverse: Not Logged In";
+        metaverseDetails = " (Metaverse: Not Logged In)";
     }
 
     QString domainDetails;
-    if (currentPlaceName == authedDomain && isDomainLoggedIn) {
-        domainDetails = "Domain: Logged in as " + domainUsername;
+    if (hasDomainLogIn) {
+        if (currentPlaceName == authedDomain && isDomainLoggedIn) {
+            domainDetails = " (Domain: Logged in as " + domainUsername + ")";
+        } else {
+            domainDetails = " (Domain: Not Logged In)";
+        }
     } else {
-        domainDetails = "Domain: Not Logged In";
+        domainDetails = "";
     }
 
-    QString title = QString() + currentPlaceName + connectionStatus + " (" + metaverseDetails + ") (" + domainDetails + ")" 
-        + buildVersion;
+    QString title = currentPlaceName + connectionStatus + metaverseDetails + domainDetails + buildVersion;
 
 #ifndef WIN32
     // crashes with vs2013/win32

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -7086,7 +7086,7 @@ void Application::updateWindowTitle() const {
     bool isMetaverseLoggedIn = accountManager->isLoggedIn();
     bool hasDomainLogIn = domainAccountManager->hasLogIn();
     bool isDomainLoggedIn = domainAccountManager->isLoggedIn();
-    QString authedDomain = domainAccountManager->getAuthedDomain();
+    QString authedDomainName = domainAccountManager->getAuthedDomainName();
 
     QString buildVersion = " - Vircadia - "
         + (BuildInfo::BUILD_TYPE == BuildInfo::BuildType::Stable ? QString("Version") : QString("Build"))
@@ -7123,7 +7123,7 @@ void Application::updateWindowTitle() const {
 
     QString domainDetails;
     if (hasDomainLogIn) {
-        if (currentPlaceName == authedDomain && isDomainLoggedIn) {
+        if (currentPlaceName == authedDomainName && isDomainLoggedIn) {
             domainDetails = " (Domain: Logged in as " + domainUsername + ")";
         } else {
             domainDetails = " (Domain: Not Logged In)";

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -43,6 +43,7 @@
 #include "avatar/AvatarManager.h"
 #include "avatar/AvatarPackager.h"
 #include "AvatarBookmarks.h"
+#include "DomainAccountManager.h"
 #include "MainWindow.h"
 #include "render/DrawStatus.h"
 #include "scripting/MenuScriptingInterface.h"
@@ -73,6 +74,7 @@ const char* EXCLUSION_GROUP_KEY = "exclusionGroup";
 Menu::Menu() {
     auto dialogsManager = DependencyManager::get<DialogsManager>();
     auto accountManager = DependencyManager::get<AccountManager>();
+    auto domainAccountManager = DependencyManager::get<DomainAccountManager>();
 
     // File/Application menu ----------------------------------
     MenuWrapper* fileMenu = addMenu("File");
@@ -89,10 +91,14 @@ Menu::Menu() {
     }
 
     auto domainLogin = addActionToQMenuAndActionHash(fileMenu, "Domain: Log In");
+    domainLogin->setVisible(false);
     connect(domainLogin, &QAction::triggered, [] {
         auto dialogsManager = DependencyManager::get<DialogsManager>();
         dialogsManager->setDomainLoginState();
         dialogsManager->showDomainLoginDialog();
+    });
+    connect(domainAccountManager.data(), &DomainAccountManager::hasLogInChanged, [domainLogin](bool hasLogIn) {
+        domainLogin->setVisible(hasLogIn);
     });
 
     // File > Quit

--- a/libraries/networking/src/DomainAccountManager.cpp
+++ b/libraries/networking/src/DomainAccountManager.cpp
@@ -57,17 +57,19 @@ void DomainAccountManager::setDomainURL(const QUrl& domainURL) {
         _authURL = _previousAuthURL;
         _clientID = _previousClientID;
         _username = _previousUsername;
-        _access_token = _previousAccessToken;
-        _refresh_token = _previousRefreshToken;
-        _domain_name = _previousDomainName;
+        _accessToken = _previousAccessToken;
+        _refreshToken = _previousRefreshToken;
+        _authedDomainName = _previousAuthedDomainName;
+
         // ####### TODO: Refresh OAuth2 access token if necessary.
+
     } else {
         _authURL.clear();
         _clientID.clear();
         _username.clear();
-        _access_token.clear();
-        _refresh_token.clear();
-        _domain_name.clear();
+        _accessToken.clear();
+        _refreshToken.clear();
+        _authedDomainName.clear();
     }
 
 }
@@ -81,8 +83,8 @@ void DomainAccountManager::setAuthURL(const QUrl& authURL) {
     qCDebug(networking) << "DomainAccountManager URL for authenticated requests has been changed to" 
         << qPrintable(_authURL.toString());
 
-    _access_token = "";
-    _refresh_token = "";
+    _accessToken = "";
+    _refreshToken = "";
 }
 
 bool DomainAccountManager::hasLogIn() {
@@ -96,8 +98,8 @@ bool DomainAccountManager::isLoggedIn() {
 void DomainAccountManager::requestAccessToken(const QString& username, const QString& password) {
 
     _username = username;
-    _access_token = "";
-    _refresh_token = "";
+    _accessToken = "";
+    _refreshToken = "";
 
     QNetworkRequest request;
 
@@ -136,7 +138,7 @@ void DomainAccountManager::requestAccessTokenFinished() {
         if (rootObject.contains("access_token")) {
             // Success.
             auto nodeList = DependencyManager::get<NodeList>();
-            _domain_name = nodeList->getDomainHandler().getHostname();
+            _authedDomainName = nodeList->getDomainHandler().getHostname();
             QUrl rootURL = requestReply->url();
             rootURL.setPath("");
             setTokensFromJSON(rootObject, rootURL);
@@ -146,9 +148,9 @@ void DomainAccountManager::requestAccessTokenFinished() {
             _previousAuthURL = _authURL;
             _previousClientID = _clientID;
             _previousUsername = _username;
-            _previousAccessToken = _access_token;
-            _previousRefreshToken = _refresh_token;
-            _previousDomainName = _domain_name;
+            _previousAccessToken = _accessToken;
+            _previousRefreshToken = _refreshToken;
+            _previousAuthedDomainName = _authedDomainName;
 
             // ####### TODO: Handle "keep me logged in".
 
@@ -183,7 +185,7 @@ bool DomainAccountManager::accessTokenIsExpired() {
 bool DomainAccountManager::hasValidAccessToken() {
     // ###### TODO: wire this up to actually retrieve a token (based on session or storage) and confirm that it is in fact valid and relevant to the current domain.
     // QString currentDomainAccessToken = domainAccessToken.get();
-    QString currentDomainAccessToken = _access_token;
+    QString currentDomainAccessToken = _accessToken;
 
     // if (currentDomainAccessToken.isEmpty() || accessTokenIsExpired()) {
     if (currentDomainAccessToken.isEmpty()) {
@@ -205,8 +207,8 @@ bool DomainAccountManager::hasValidAccessToken() {
 }
 
 void DomainAccountManager::setTokensFromJSON(const QJsonObject& jsonObject, const QUrl& url) {
-    _access_token = jsonObject["access_token"].toString();
-    _refresh_token = jsonObject["refresh_token"].toString();
+    _accessToken = jsonObject["access_token"].toString();
+    _refreshToken = jsonObject["refresh_token"].toString();
 
     // ####### TODO: Enable and use these?
     // ####### TODO: Protect these per AccountManager?

--- a/libraries/networking/src/DomainAccountManager.cpp
+++ b/libraries/networking/src/DomainAccountManager.cpp
@@ -34,10 +34,7 @@ DomainAccountManager::DomainAccountManager() {
 }
 
 void DomainAccountManager::setDomainURL(const QUrl& domainURL) {
-    qDebug() << "####### DomainAccountManager::setDomainURL()" << domainURL;
-
     if (domainURL == _currentAuth.domainURL) {
-        qDebug() << "####... Early return";
         return;
     }
 

--- a/libraries/networking/src/DomainAccountManager.cpp
+++ b/libraries/networking/src/DomainAccountManager.cpp
@@ -51,6 +51,7 @@ void DomainAccountManager::setDomainURL(const QUrl& domainURL) {
         _currentAuth.domainURL = domainURL;
     }
 
+    emit hasLogInChanged(hasLogIn());
 }
 
 void DomainAccountManager::setAuthURL(const QUrl& authURL) {
@@ -64,6 +65,8 @@ void DomainAccountManager::setAuthURL(const QUrl& authURL) {
 
     _currentAuth.accessToken = "";
     _currentAuth.refreshToken = "";
+
+    emit hasLogInChanged(hasLogIn());
 }
 
 bool DomainAccountManager::hasLogIn() {

--- a/libraries/networking/src/DomainAccountManager.h
+++ b/libraries/networking/src/DomainAccountManager.h
@@ -18,6 +18,17 @@
 #include <DependencyManager.h>
 
 
+struct DomainAccountDetails {
+    QUrl domainURL;
+    QUrl authURL;
+    QString clientID;
+    QString username;
+    QString accessToken;
+    QString refreshToken;
+    QString authedDomainName;
+};
+
+
 class DomainAccountManager : public QObject, public Dependency {
     Q_OBJECT
 public:
@@ -25,12 +36,12 @@ public:
 
     void setDomainURL(const QUrl& domainURL);
     void setAuthURL(const QUrl& authURL);
-    void setClientID(const QString& clientID) { _clientID = clientID; }
+    void setClientID(const QString& clientID) { _currentAuth.clientID = clientID; }
 
-    const QString& getUsername() { return _username; }
-    const QString& getAccessToken() { return _accessToken; }
-    const QString& getRefreshToken() { return _refreshToken; }
-    const QString& getAuthedDomainName() { return _authedDomainName; }
+    const QString& getUsername() { return _currentAuth.username; }
+    const QString& getAccessToken() { return _currentAuth.accessToken; }
+    const QString& getRefreshToken() { return _currentAuth.refreshToken; }
+    const QString& getAuthedDomainName() { return _currentAuth.authedDomainName; }
 
     bool hasLogIn();
     bool isLoggedIn();
@@ -56,23 +67,8 @@ private:
     void setTokensFromJSON(const QJsonObject&, const QUrl& url);
     void sendInterfaceAccessTokenToServer();
 
-    QUrl _domainURL;
-    QUrl _authURL;
-    QString _clientID;
-
-    QString _username;
-    QString _accessToken;
-    QString _refreshToken;
-    QString _authedDomainName;
-
-    // ####### TODO: Handle more than one domain.
-    QUrl _previousDomainURL;
-    QUrl _previousAuthURL;
-    QString _previousClientID;
-    QString _previousUsername;
-    QString _previousAccessToken;
-    QString _previousRefreshToken;
-    QString _previousAuthedDomainName;
+    DomainAccountDetails _currentAuth;
+    QHash<QUrl, DomainAccountDetails> _knownAuths;  // <domainURL, DomainAccountDetails>
 };
 
 #endif  // hifi_DomainAccountManager_h

--- a/libraries/networking/src/DomainAccountManager.h
+++ b/libraries/networking/src/DomainAccountManager.h
@@ -53,6 +53,7 @@ public slots:
     void requestAccessTokenFinished();
 
 signals:
+    void hasLogInChanged(bool hasLogIn);
     void authRequired(const QString& domain);
     void loginComplete();
     void loginFailed();

--- a/libraries/networking/src/DomainAccountManager.h
+++ b/libraries/networking/src/DomainAccountManager.h
@@ -23,6 +23,7 @@ class DomainAccountManager : public QObject, public Dependency {
 public:
     DomainAccountManager();
 
+    void setDomainURL(const QUrl& domainURL);
     void setAuthURL(const QUrl& authURL);
     void setClientID(const QString& clientID) { _clientID = clientID; }
 
@@ -31,6 +32,7 @@ public:
     QString getRefreshToken() { return _refresh_token; }
     QString getAuthedDomain() { return _domain_name; }
 
+    bool hasLogIn();
     bool isLoggedIn();
 
     Q_INVOKABLE bool checkAndSignalForAccessToken();
@@ -55,12 +57,23 @@ private:
     void setTokensFromJSON(const QJsonObject&, const QUrl& url);
     void sendInterfaceAccessTokenToServer();
 
+    QUrl _domainURL;
     QUrl _authURL;
     QString _clientID;
-    QString _username;      // ####### TODO: Store elsewhere?
+
+    QString _username;
     QString _access_token;  // ####... ""
     QString _refresh_token; // ####... ""
     QString _domain_name;   // ####... ""
+
+    // ####### TODO: Handle more than one domain.
+    QUrl _previousDomainURL;
+    QUrl _previousAuthURL;
+    QString _previousClientID;
+    QString _previousUsername;
+    QString _previousAccessToken;
+    QString _previousRefreshToken;
+    QString _previousDomainName;
 };
 
 #endif  // hifi_DomainAccountManager_h

--- a/libraries/networking/src/DomainAccountManager.h
+++ b/libraries/networking/src/DomainAccountManager.h
@@ -60,8 +60,6 @@ signals:
     void logoutComplete();
     void newTokens();
 
-private slots:
-
 private:
     bool hasValidAccessToken();
     bool accessTokenIsExpired();

--- a/libraries/networking/src/DomainAccountManager.h
+++ b/libraries/networking/src/DomainAccountManager.h
@@ -27,10 +27,10 @@ public:
     void setAuthURL(const QUrl& authURL);
     void setClientID(const QString& clientID) { _clientID = clientID; }
 
-    QString getUsername() { return _username; }
-    QString getAccessToken() { return _access_token; }
-    QString getRefreshToken() { return _refresh_token; }
-    QString getAuthedDomain() { return _domain_name; }
+    const QString& getUsername() { return _username; }
+    const QString& getAccessToken() { return _accessToken; }
+    const QString& getRefreshToken() { return _refreshToken; }
+    const QString& getAuthedDomainName() { return _authedDomainName; }
 
     bool hasLogIn();
     bool isLoggedIn();
@@ -39,7 +39,6 @@ public:
 
 public slots:
     void requestAccessToken(const QString& username, const QString& password);
-    
     void requestAccessTokenFinished();
 
 signals:
@@ -62,9 +61,9 @@ private:
     QString _clientID;
 
     QString _username;
-    QString _access_token;  // ####... ""
-    QString _refresh_token; // ####... ""
-    QString _domain_name;   // ####... ""
+    QString _accessToken;
+    QString _refreshToken;
+    QString _authedDomainName;
 
     // ####### TODO: Handle more than one domain.
     QUrl _previousDomainURL;
@@ -73,7 +72,7 @@ private:
     QString _previousUsername;
     QString _previousAccessToken;
     QString _previousRefreshToken;
-    QString _previousDomainName;
+    QString _previousAuthedDomainName;
 };
 
 #endif  // hifi_DomainAccountManager_h

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -531,7 +531,7 @@ bool DomainHandler::reasonSuggestsDomainLogin(ConnectionRefusedReason reasonCode
 void DomainHandler::processDomainServerConnectionDeniedPacket(QSharedPointer<ReceivedMessage> message) {
 
     // Ignore any residual packets from previous domain.
-    if (message->getSenderSockAddr().getAddress().toString() != _domainURL.host()) {
+    if (!message->getSenderSockAddr().getAddress().isEqual(_sockAddr.getAddress())) {
         return;
     }
 

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -529,6 +529,12 @@ bool DomainHandler::reasonSuggestsDomainLogin(ConnectionRefusedReason reasonCode
 }
 
 void DomainHandler::processDomainServerConnectionDeniedPacket(QSharedPointer<ReceivedMessage> message) {
+
+    // Ignore any residual packets from previous domain.
+    if (message->getSenderSockAddr().getAddress().toString() != _domainURL.host()) {
+        return;
+    }
+
     // we're hearing from this domain-server, don't need to refresh API info
     _apiRefreshTimer.stop();
 

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -476,33 +476,28 @@ void NodeList::sendDomainServerCheckIn() {
         packetStream << _ownerType.load() << publicSockAddr << localSockAddr << _nodeTypesOfInterest.toList();
         packetStream << DependencyManager::get<AddressManager>()->getPlaceName();
 
-        // ####### TODO: Also send if need to send new domainLogin data?
         if (!domainIsConnected) {
+
+            // Metaverse account.
             DataServerAccountInfo& accountInfo = accountManager->getAccountInfo();
             packetStream << accountInfo.getUsername();
-
             // if this is a connect request, and we can present a username signature, send it along
             if (requiresUsernameSignature && accountManager->getAccountInfo().hasPrivateKey()) {
                 const QByteArray& usernameSignature = accountManager->getAccountInfo().getUsernameSignature(connectionToken);
                 packetStream << usernameSignature;
             } else {
-                // ####### TODO: Only append if are going to send domain username?
                 packetStream << QString("");  // Placeholder in case have domain username.
             }
-        } else {
-            // ####### TODO: Only append if are going to send domainUsername?
-            packetStream << QString("") << QString("");  // Placeholders in case have domain username.
-        }
 
-        // Send domain domain login data from Interface to domain server.
-        if (_hasDomainAccountManager) {
-            auto domainAccountManager = DependencyManager::get<DomainAccountManager>();
-            if (!domainAccountManager->getUsername().isEmpty()) {
-                packetStream << domainAccountManager->getUsername();
-                if (!domainAccountManager->getAccessToken().isEmpty()) {
+            // Domain account.
+            if (_hasDomainAccountManager) {
+                auto domainAccountManager = DependencyManager::get<DomainAccountManager>();
+                if (!domainAccountManager->getUsername().isEmpty() && !domainAccountManager->getAccessToken().isEmpty()) {
+                    packetStream << domainAccountManager->getUsername();
                     packetStream << (domainAccountManager->getAccessToken() + ":" + domainAccountManager->getRefreshToken());
                 }
             }
+
         }
 
         flagTimeForConnectionStep(LimitedNodeList::ConnectionStep::SendDSCheckIn);


### PR DESCRIPTION
The following items are only displayed on domains that have domain login:
- Title bar: (Domain: <login status>)
- Menu item: The File > Domain: Log In 

Also:
- Ignores "connection denied" packets from previous domain, to prevent erroneous domain login dialog displaying.
- Handles domain login for multiple WordPress domains. (Can log into one, teleport to another and log in there also, then teleport between the two without having to log in again.)