### PR TITLE
changed url for AC script examples from HiFi to Vircadia github

### DIFF
--- a/domain-server/resources/web/assignment/placeholder.js
+++ b/domain-server/resources/web/assignment/placeholder.js
@@ -1,3 +1,3 @@
 // Here you can put a script that will be run by an assignment-client (AC)
-// For examples, please go to https://github.com/highfidelity/hifi/tree/master/script-archive/acScripts
+// For examples, please go to https://github.com/kasenvr/project-athena/tree/master/script-archive/acScripts
 // The directory named acScripts contains assignment-client specific scripts you can try.


### PR DESCRIPTION
When you click on the Assignment tab in the server settings, the placeholder comments refer to hifi github, so changing it to vircadia github. :)
<img width="1114" alt="Screen Shot 2020-08-23 at 1 25 49 PM" src="https://user-images.githubusercontent.com/6512223/90988035-70217880-e544-11ea-954b-1fd2455ecdf1.png">
