### PR TITLE
Fix build of hifiSdl2 on GCC 10

### DIFF
--- a/plugins/hifiSdl2/CMakeLists.txt
+++ b/plugins/hifiSdl2/CMakeLists.txt
@@ -8,6 +8,13 @@
 
 if (NOT APPLE)
     set(TARGET_NAME hifiSdl2)
+    if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 10.0)
+        # GCC 10 and above sets -fno-common by default, and causes a linking problem here:
+        # multiple definition of `WAYLAND_wl_proxy_marshal'
+        #
+        # Work around it per https://medium.com/@clentfort/using-esy-sdl2-with-gcc-10-91b4fa0c5aa9
+        link_libraries("-Wl,--allow-multiple-definition")
+    endif()
     setup_hifi_plugin(Qml)
     link_hifi_libraries(shared controllers ui plugins input-plugins script-engine)
     target_sdl2()


### PR DESCRIPTION
GCC 10 and above sets -fno-common by default, and causes a linking problem here:
Multiple definition of `WAYLAND_wl_proxy_marshal'

Work around it per https://medium.com/@clentfort/using-esy-sdl2-with-gcc-10-91b4fa0c5aa9

This fixes the build on Fedora 32, and similarly new distributions that come with GCC 10.

This is probably not the best fix possible, since the better thing to do would be to fix the linking issue, but I've not dug into the details of why it happens, and why only with the Wayland symbols.
