### PR TITLE
Fix build on qt 5.14

### DIFF
--- a/assignment-client/src/audio/AudioMixerClientData.h
+++ b/assignment-client/src/audio/AudioMixerClientData.h
@@ -14,7 +14,10 @@
 
 #include <queue>
 
+#if !defined(Q_MOC_RUN)
+// Work around https://bugreports.qt.io/browse/QTBUG-80990
 #include <tbb/concurrent_vector.h>
+#endif
 
 #include <QtCore/QJsonObject>
 

--- a/assignment-client/src/audio/AudioMixerSlave.h
+++ b/assignment-client/src/audio/AudioMixerSlave.h
@@ -12,7 +12,10 @@
 #ifndef hifi_AudioMixerSlave_h
 #define hifi_AudioMixerSlave_h
 
+#if !defined(Q_MOC_RUN)
+// Work around https://bugreports.qt.io/browse/QTBUG-80990
 #include <tbb/concurrent_vector.h>
+#endif
 
 #include <AABox.h>
 #include <AudioHRTF.h>

--- a/libraries/input-plugins/src/input-plugins/TouchscreenVirtualPadDevice.h
+++ b/libraries/input-plugins/src/input-plugins/TouchscreenVirtualPadDevice.h
@@ -15,7 +15,12 @@
 #include <controllers/InputDevice.h>
 #include "InputPlugin.h"
 #include <QtGui/qtouchdevice.h>
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
 #include <QtGui/QList>
+#else
+#include <QTouchEvent>
+#include <QtCore/QList>
+#endif
 #include "VirtualPadManager.h"
 
 class QTouchEvent;

--- a/libraries/material-networking/src/material-networking/TextureCache.cpp
+++ b/libraries/material-networking/src/material-networking/TextureCache.cpp
@@ -223,12 +223,14 @@ public:
 };
 
 namespace std {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
     template <>
     struct hash<QByteArray> {
         size_t operator()(const QByteArray& byteArray) const {
             return qHash(byteArray);
         }
     };
+#endif
 
     template <>
     struct hash<TextureExtra> {

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -597,12 +597,14 @@ namespace std {
         }
     };
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
     template <>
     struct hash<QString> {
         size_t operator()(const QString& a) const {
             return qHash(a);
         }
     };
+#endif
 }
 
 /**jsdoc

--- a/libraries/shared/src/TBBHelpers.h
+++ b/libraries/shared/src/TBBHelpers.h
@@ -15,12 +15,15 @@
 #pragma warning( disable : 4334 )
 #endif
 
+#if !defined(Q_MOC_RUN)
+// Work around https://bugreports.qt.io/browse/QTBUG-80990
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_map.h>
 #include <tbb/concurrent_unordered_set.h>
 #include <tbb/concurrent_vector.h>
 #include <tbb/parallel_for.h>
 #include <tbb/blocked_range2d.h>
+#endif
 
 #ifdef _WIN32
 #pragma warning( pop )


### PR DESCRIPTION
This fixes the build on Qt 5.14 and above. Tested on 5.14.2 and 5.15.

Building under new Qt versions generates a lot of deprecation warnings, those will be addressed later.

So far 5.14.2 seems to work fine, and 5.15 seems to hang shortly after start for an unknown reason. The end goal here is to get 5.15 to work, since that should be the first version Vircadia can use without patching.

