### PR TITLE
Add option to capture mouse

### DIFF
--- a/interface/resources/controllers/keyboardMouse.json
+++ b/interface/resources/controllers/keyboardMouse.json
@@ -213,12 +213,30 @@
             ]
         },
 
+        { "from": { "makeAxis" : ["Keyboard.MouseMoveLeft", "Keyboard.MouseMoveRight"] },
+          "to": "Actions.DeltaYaw",
+          "when": "Application.CaptureMouse",
+          "filters":
+            [
+                { "type": "scale", "scale": 0.2 }
+            ]
+        },
+
         { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
           "when": ["!Application.CameraSelfie", "!Application.CameraLookAt", "Keyboard.RightMouseButton"],
           "to": "Actions.DeltaPitch",
           "filters":
             [
                 { "type": "scale", "scale": 0.6 }
+            ]
+        },
+
+        { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
+          "to": "Actions.DeltaPitch",
+          "when": "Application.CaptureMouse",
+          "filters":
+            [
+                { "type": "scale", "scale": 0.2 }
             ]
         },
 

--- a/interface/resources/controllers/keyboardMouse.json
+++ b/interface/resources/controllers/keyboardMouse.json
@@ -3,9 +3,9 @@
     "channels": [
         { "from": "Keyboard.A", "when": ["Keyboard.RightMouseButton", "!Keyboard.Control"], "to": "Actions.LATERAL_LEFT" },
         { "from": "Keyboard.D", "when": ["Keyboard.RightMouseButton", "!Keyboard.Control"], "to": "Actions.LATERAL_RIGHT" },
-        { "from": "Keyboard.E", "when": ["!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LATERAL_RIGHT" },
-        { "from": "Keyboard.Q", "when": ["!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LATERAL_LEFT" },
+        { "from": "Keyboard.Q", "when": ["!Application.CameraSelfie", "!Keyboard.Control", "!Application.CaptureMouse"], "to": "Actions.LATERAL_LEFT" },
         { "from": "Keyboard.Q", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LATERAL_RIGHT" },
+        { "from": "Keyboard.E", "when": ["!Application.CameraSelfie", "!Keyboard.Control", "!Application.CaptureMouse"], "to": "Actions.LATERAL_RIGHT" },
         { "from": "Keyboard.E", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LATERAL_LEFT" },
         { "from": "Keyboard.T", "when": "!Keyboard.Control", "to": "Actions.TogglePushToTalk" },
 
@@ -72,46 +72,20 @@
         { "from": { "makeAxis" : [
                 ["Keyboard.Left"],
                 ["Keyboard.Right"]
-             ]
+            ]
           },
-          "when": ["Application.CameraFirstPerson", "!Keyboard.Shift"],
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "!Application.CaptureMouse", "!Keyboard.Shift"],
           "to": "Actions.Yaw"
         },
 
-        { "from": { "makeAxis" : [
-                ["Keyboard.Left"],
-                ["Keyboard.Right"]
-             ]
-          },
-          "when": ["Application.CameraFirstPersonLookat", "!Keyboard.Shift"],
-          "to": "Actions.Yaw"
+        { "from": "Keyboard.Left",
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Shift"],
+          "to": "Actions.LATERAL_LEFT"
         },
 
-        { "from": { "makeAxis" : [
-                ["Keyboard.Left"],
-                ["Keyboard.Right"]
-             ]
-          },
-          "when": ["Application.CameraThirdPerson", "!Keyboard.Shift"],
-          "to": "Actions.Yaw"
-        },
-        
-        { "from": { "makeAxis" : [
-                ["Keyboard.Left"],
-                ["Keyboard.Right"]
-             ]
-          },
-          "when": ["Application.CameraLookAt", "!Keyboard.Shift"],
-          "to": "Actions.Yaw"
-        },
-
-        { "from": { "makeAxis" : [
-                ["Keyboard.Left"],
-                ["Keyboard.Right"]
-             ]
-          },
-          "when": ["Application.CameraSelfie", "!Keyboard.Shift"],
-          "to": "Actions.Yaw"
+        { "from": "Keyboard.Right",
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Shift"],
+          "to": "Actions.LATERAL_RIGHT"
         },
 
         { "from": { "makeAxis" : [
@@ -119,53 +93,18 @@
                 ["Keyboard.D"]
             ]
           },
-          "when": ["Application.CameraFirstPerson", "!Keyboard.Control"],
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "!Application.CaptureMouse", "!Keyboard.Control"],
           "to": "Actions.Yaw"
         },
 
-        { "from": { "makeAxis" : [
-                ["Keyboard.A"],
-                ["Keyboard.D"]
-            ]
-          },
-          "when": ["Application.CameraFirstPersonLookat", "!Keyboard.Control"],
-          "to": "Actions.Yaw"
+        { "from": "Keyboard.A",
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Control"],
+          "to": "Actions.LATERAL_LEFT"
         },
 
-        { "from": { "makeAxis" : [
-                ["Keyboard.A"],
-                ["Keyboard.D"]
-            ]
-          },
-          "when": ["Application.CameraThirdPerson", "!Keyboard.Control"],
-          "to": "Actions.Yaw"
-        },
-        
-        { "from": { "makeAxis" : [
-                ["Keyboard.A"],
-                ["Keyboard.D"]
-             ]
-          },
-          "when": ["Application.CameraLookAt", "!Keyboard.Control"],
-          "to": "Actions.Yaw"
-        },
-
-        { "from": { "makeAxis" : [
-                ["Keyboard.A"],
-                ["Keyboard.D"]
-             ]
-          },
-          "when": ["Application.CameraSelfie", "!Keyboard.Control"],
-          "to": "Actions.Yaw"
-        },
-        
-        { "from": { "makeAxis" : [
-                ["Keyboard.TouchpadLeft"],
-                ["Keyboard.TouchpadRight"]
-            ]
-          },
-          "when": "Application.CameraFirstPerson",
-          "to": "Actions.Yaw"
+        { "from": "Keyboard.D",
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Control"],
+          "to": "Actions.LATERAL_RIGHT"
         },
 
         { "from": { "makeAxis" : [
@@ -173,39 +112,12 @@
                 ["Keyboard.TouchpadRight"]
             ]
           },
-          "when": "Application.CameraFirstPersonLookat",
-          "to": "Actions.Yaw"
-        },
-        
-        { "from": { "makeAxis" : [
-                ["Keyboard.TouchpadLeft"],
-                ["Keyboard.TouchpadRight"]
-            ]
-          },
-          "when": "Application.CameraThirdPerson",
-          "to": "Actions.Yaw"
-        },
-        
-        { "from": { "makeAxis" : [
-                ["Keyboard.TouchpadLeft"],
-                ["Keyboard.TouchpadRight"]
-            ]
-          },
-          "when": "Application.CameraLookAt",
-          "to": "Actions.Yaw"
-        },
-        
-        { "from": { "makeAxis" : [
-                ["Keyboard.TouchpadLeft"],
-                ["Keyboard.TouchpadRight"]
-            ]
-          },
-          "when": "Application.CameraSelfie",
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity"],
           "to": "Actions.Yaw"
         },
 
         { "from": { "makeAxis" : ["Keyboard.MouseMoveLeft", "Keyboard.MouseMoveRight"] },
-          "when": "Keyboard.RightMouseButton",
+          "when": ["Keyboard.RightMouseButton", "!Application.CaptureMouse"],
           "to": "Actions.DeltaYaw",
           "filters":
             [
@@ -223,7 +135,7 @@
         },
 
         { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
-          "when": ["!Application.CameraSelfie", "!Application.CameraLookAt", "Keyboard.RightMouseButton"],
+          "when": ["!Application.CameraSelfie", "!Application.CameraLookAt", "!Application.CaptureMouse", "Keyboard.RightMouseButton"],
           "to": "Actions.DeltaPitch",
           "filters":
             [

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -680,7 +680,9 @@ private:
  *     <tr><td><code>CameraIndependent</code></td><td>number</td><td>number</td><td>The camera is in independent mode.</td></tr>
  *     <tr><td><code>CameraEntity</code></td><td>number</td><td>number</td><td>The camera is in entity mode.</td></tr>
  *     <tr><td><code>InHMD</code></td><td>number</td><td>number</td><td>The user is in HMD mode.</td></tr>
- *     <tr><td><code>CaptureMouse</code></td><td>number</td><td>number</td><td>The mouse is captured.</td></tr>
+ *     <tr><td><code>CaptureMouse</code></td><td>number</td><td>number</td><td>The mouse is captured.  In this mode,
+ *       the mouse is invisible and cannot leave the bounds of Interface, as long as Interface is the active window and
+ *       no menu item is selected.</td></tr>
  *     <tr><td><code>AdvancedMovement</code></td><td>number</td><td>number</td><td>Advanced movement (walking) controls are
  *       enabled.</td></tr>
  *     <tr><td><code>StrafeEnabled</code></td><td>number</td><td>number</td><td>Strafing is enabled</td></tr>
@@ -716,7 +718,7 @@ static const QString STATE_PLATFORM_ANDROID = "PlatformAndroid";
 static const QString STATE_LEFT_HAND_DOMINANT = "LeftHandDominant";
 static const QString STATE_RIGHT_HAND_DOMINANT = "RightHandDominant";
 static const QString STATE_STRAFE_ENABLED = "StrafeEnabled";
-static const QString STATE_CAMERA_CAPTURE_MOUSE = "CaptureMouse";
+static const QString STATE_CAPTURE_MOUSE = "CaptureMouse";
 
 // Statically provided display and input plugins
 extern DisplayPluginList getDisplayPlugins();
@@ -920,7 +922,7 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     DependencyManager::set<MessagesClient>();
     controller::StateController::setStateVariables({ { STATE_IN_HMD, STATE_CAMERA_FULL_SCREEN_MIRROR,
                     STATE_CAMERA_FIRST_PERSON, STATE_CAMERA_FIRST_PERSON_LOOK_AT, STATE_CAMERA_THIRD_PERSON,
-                    STATE_CAMERA_ENTITY, STATE_CAMERA_INDEPENDENT, STATE_CAMERA_LOOK_AT, STATE_CAMERA_SELFIE, STATE_CAMERA_CAPTURE_MOUSE,
+                    STATE_CAMERA_ENTITY, STATE_CAMERA_INDEPENDENT, STATE_CAMERA_LOOK_AT, STATE_CAMERA_SELFIE, STATE_CAPTURE_MOUSE,
                     STATE_SNAP_TURN, STATE_ADVANCED_MOVEMENT_CONTROLS, STATE_GROUNDED, STATE_NAV_FOCUSED,
                     STATE_PLATFORM_WINDOWS, STATE_PLATFORM_MAC, STATE_PLATFORM_ANDROID, STATE_LEFT_HAND_DOMINANT, STATE_RIGHT_HAND_DOMINANT, STATE_STRAFE_ENABLED } });
     DependencyManager::set<UserInputMapper>();
@@ -1893,7 +1895,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     _applicationStateDevice->setInputVariant(STATE_CAMERA_INDEPENDENT, []() -> float {
         return qApp->getCamera().getMode() == CAMERA_MODE_INDEPENDENT ? 1 : 0;
     });
-    _applicationStateDevice->setInputVariant(STATE_CAMERA_CAPTURE_MOUSE, []() -> float {
+    _applicationStateDevice->setInputVariant(STATE_CAPTURE_MOUSE, []() -> float {
         return qApp->getCamera().getCaptureMouse() ? 1 : 0;
     });
     _applicationStateDevice->setInputVariant(STATE_SNAP_TURN, []() -> float {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2413,7 +2413,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     updateSystemTabletMode();
 
     connect(&_myCamera, &Camera::modeUpdated, this, &Application::cameraModeChanged);
-    connect(&_myCamera, &Camera::captureMouseUpdated, this, &Application::captureMouseChanged);
+    connect(&_myCamera, &Camera::captureMouseChanged, this, &Application::captureMouseChanged);
 
     DependencyManager::get<PickManager>()->setShouldPickHUDOperator([]() { return DependencyManager::get<HMDScriptingInterface>()->isHMDMode(); });
     DependencyManager::get<PickManager>()->setCalculatePos2DFromHUDOperator([this](const glm::vec3& intersection) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5922,19 +5922,7 @@ void Application::cameraModeChanged() {
 }
 
 bool Application::shouldCaptureMouse() const {
-    if (!_captureMouse) {
-        return false;
-    }
-
-    if (!_glWidget->isActiveWindow()) {
-        return false;
-    }
-
-    if (ui::Menu::isSomeSubmenuShown()) {
-        return false;
-    }
-
-    return true;
+    return _captureMouse && _glWidget->isActiveWindow() && !ui::Menu::isSomeSubmenuShown();
 }
 
 void Application::captureMouseChanged(bool captureMouse) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5921,6 +5921,22 @@ void Application::cameraModeChanged() {
     cameraMenuChanged();
 }
 
+bool Application::shouldCaptureMouse() const {
+    if (!_captureMouse) {
+        return false;
+    }
+
+    if (!_glWidget->isActiveWindow()) {
+        return false;
+    }
+
+    if (ui::Menu::isSomeSubmenuShown()) {
+        return false;
+    }
+
+    return true;
+}
+
 void Application::captureMouseChanged(bool captureMouse) {
     _captureMouse = captureMouse;
     if (_captureMouse) {
@@ -6281,7 +6297,7 @@ void Application::update(float deltaTime) {
         PROFILE_ASYNC_END(app, "Scene Loading", "");
     }
 
-     if (_captureMouse) {
+     if (shouldCaptureMouse()) {
         QPoint point = _glWidget->mapToGlobal(_glWidget->geometry().center());
         if (QCursor::pos() != point) {
             _mouseCaptureTarget = point;

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6351,8 +6351,8 @@ void Application::update(float deltaTime) {
                 if (deltaTime > FLT_EPSILON && userInputMapper->getActionState(controller::Action::TRANSLATE_CAMERA_Z)  == 0.0f) {
                     myAvatar->setDriveKey(MyAvatar::PITCH, -1.0f * userInputMapper->getActionState(controller::Action::PITCH));
                     myAvatar->setDriveKey(MyAvatar::YAW, -1.0f * userInputMapper->getActionState(controller::Action::YAW));
-                    myAvatar->setDriveKey(MyAvatar::DELTA_PITCH, -1.0f * userInputMapper->getActionState(controller::Action::DELTA_PITCH));
-                    myAvatar->setDriveKey(MyAvatar::DELTA_YAW, -1.0f * userInputMapper->getActionState(controller::Action::DELTA_YAW));
+                    myAvatar->setDriveKey(MyAvatar::DELTA_PITCH, -_myCamera.getSensitivity() * userInputMapper->getActionState(controller::Action::DELTA_PITCH));
+                    myAvatar->setDriveKey(MyAvatar::DELTA_YAW, -_myCamera.getSensitivity() * userInputMapper->getActionState(controller::Action::DELTA_YAW));
                     myAvatar->setDriveKey(MyAvatar::STEP_YAW, -1.0f * userInputMapper->getActionState(controller::Action::STEP_YAW));
                 }
             }

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -430,6 +430,7 @@ public slots:
     void cycleCamera();
     void cameraModeChanged();
     void cameraMenuChanged();
+    void captureMouseChanged();
     void toggleOverlays();
     void setOverlaysVisible(bool visible);
     Q_INVOKABLE void centerUI();

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -430,7 +430,7 @@ public slots:
     void cycleCamera();
     void cameraModeChanged();
     void cameraMenuChanged();
-    void captureMouseChanged();
+    void captureMouseChanged(bool captureMouse);
     void toggleOverlays();
     void setOverlaysVisible(bool visible);
     Q_INVOKABLE void centerUI();
@@ -756,7 +756,9 @@ private:
 
     bool _settingsLoaded { false };
 
-    bool _fakedMouseEvent { false };
+    bool _captureMouse { false };
+    bool _ignoreMouseMove { false };
+    QPointF _mouseCaptureTarget { NAN, NAN };
 
     bool _isMissingSequenceNumbers { false };
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -603,6 +603,7 @@ private:
 
     void maybeToggleMenuVisible(QMouseEvent* event) const;
     void toggleTabletUI(bool shouldOpen = false) const;
+    bool shouldCaptureMouse() const;
 
     void userKickConfirmation(const QUuid& nodeID);
 

--- a/interface/src/FancyCamera.h
+++ b/interface/src/FancyCamera.h
@@ -36,6 +36,10 @@ class FancyCamera : public Camera {
      * @property {ViewFrustum} frustum - The camera frustum.
      * @property {Uuid} cameraEntity - The ID of the entity that is used for the camera position and orientation when the 
      *     camera is in entity mode.
+     * @property {boolean} captureMouse - The mouse capture state.  When <code>true</code>, the mouse is invisible and cannot leave the bounds of
+     * Interface, as long as Interface is the active window and no menu item is selected.  When <code>false</code>, the mouse
+     * behaves normally.
+     * @property {number} sensitivity - The current camera sensitivity.  Must be positive.
      */
     Q_PROPERTY(QUuid cameraEntity READ getCameraEntity WRITE setCameraEntity)
 

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -359,6 +359,16 @@ void setupPreferences() {
         preferences->addPreference(preference);
     }
     {
+        auto getter = [myAvatar]()->float { return qApp->getCamera().getSensitivity(); };
+        auto setter = [myAvatar](float value) { qApp->getCamera().setSensitivity(value); };
+        auto preference = new SpinnerSliderPreference(VR_MOVEMENT, "Camera Sensitivity", getter, setter);
+        preference->setMin(0.01f);
+        preference->setMax(5.0f);
+        preference->setStep(0.1);
+        preference->setDecimals(2);
+        preferences->addPreference(preference);
+    }
+    {
         auto getter = [myAvatar]()->int { return myAvatar->getControlScheme(); };
         auto setter = [myAvatar](int index) { myAvatar->setControlScheme(index); };
         auto preference = new RadioButtonsPreference(VR_MOVEMENT, "Control Scheme", getter, setter);

--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
@@ -213,7 +213,6 @@ void CompositorHelper::setAllowMouseCapture(bool capture) {
         _allowMouseCapture = capture;
         emit allowMouseCaptureChanged();
     }
-    _allowMouseCapture = capture;
 }
 
 void CompositorHelper::handleLeaveEvent() {

--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
@@ -1,6 +1,7 @@
 //
 //  Created by Benjamin Arnold on 5/27/14.
 //  Copyright 2014 High Fidelity, Inc.
+//  Copyright 2020 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.h
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.h
@@ -1,6 +1,7 @@
 //
 //  Created by Bradley Austin Davis Arnold on 2015/06/13
 //  Copyright 2015 High Fidelity, Inc.
+//  Copyright 2020 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.cpp
+++ b/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by Sam Gateau on 4/27/15.
 //  Copyright 2015 High Fidelity, Inc.
+//  Copyright 2020 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.h
+++ b/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.h
@@ -4,6 +4,7 @@
 //
 //  Created by Sam Gateau on 4/27/15.
 //  Copyright 2015 High Fidelity, Inc.
+//  Copyright 2020 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.h
+++ b/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.h
@@ -79,7 +79,7 @@ public:
     void keyPressEvent(QKeyEvent* event);
     void keyReleaseEvent(QKeyEvent* event);
 
-    void mouseMoveEvent(QMouseEvent* event);
+    void mouseMoveEvent(QMouseEvent* event, bool capture, QPointF captureTarget);
     void mousePressEvent(QMouseEvent* event);
     void mouseReleaseEvent(QMouseEvent* event);
     void eraseMouseClicked();
@@ -123,7 +123,7 @@ public:
 
 protected:
     QPoint _lastCursor;
-    QPoint _previousCursor;
+    QPoint _accumulatedMove;
     QPoint _mousePressPos;
     quint64 _mousePressTime;
     qreal _lastTotalScaleFactor;

--- a/libraries/shared/src/shared/Camera.h
+++ b/libraries/shared/src/shared/Camera.h
@@ -120,7 +120,9 @@ public slots:
     bool getCaptureMouse() const { return _captureMouse; }
 
     /**jsdoc
-     * Sets the mouse capture state.
+     * Sets the mouse capture state.  When <code>true</code>, the mouse will be invisible and cannot leave the bounds of
+     * Interface, as long as Interface is the active window and no menu item is selected.  When <code>false</code>, the mouse
+     * will behave normally.
      * @function Camera.setCaptureMouse
      * @param {boolean} captureMouse - <code>true</code> to capture the mouse, <code>false</code> to release the mouse.
      */

--- a/libraries/shared/src/shared/Camera.h
+++ b/libraries/shared/src/shared/Camera.h
@@ -45,6 +45,7 @@ class Camera : public QObject {
     Q_PROPERTY(QString mode READ getModeString WRITE setModeString NOTIFY modeUpdated)
     Q_PROPERTY(QVariantMap frustum READ getViewFrustum CONSTANT)
     Q_PROPERTY(bool captureMouse READ getCaptureMouse WRITE setCaptureMouse NOTIFY captureMouseUpdated)
+    Q_PROPERTY(float sensitivity READ getSensitivity WRITE setSensitivity)
 
 public:
     Camera();
@@ -127,6 +128,20 @@ public slots:
      * @param {boolean} captureMouse - <code>true</code> to capture the mouse, <code>false</code> to release the mouse.
      */
     void setCaptureMouse(bool captureMouse) { _captureMouse = captureMouse; emit captureMouseUpdated(captureMouse); }
+
+    /**jsdoc
+     * Gets the current camera sensitivity.
+     * @function Camera.getSensitivity
+     * @returns {boolean} The current camera sensitivity.
+     */
+    float getSensitivity() const { return _sensitivity; }
+
+    /**jsdoc
+     * Sets the camera sensitivity.  Higher values mean that the camera will be more sensitive to mouse movements.
+     * @function Camera.setSensitivity
+     * @param {boolean} sensitivity - The desired camera sensitivity.
+     */
+    void setSensitivity(float sensitivity) { _sensitivity = glm::max(0.0f, sensitivity); }
 
     /**jsdoc
      * Computes a {@link PickRay} based on the current camera configuration and the specified <code>x, y</code> position on the 
@@ -228,6 +243,7 @@ private:
     glm::vec3 _lookingAt;
 
     bool _captureMouse { false };
+    float _sensitivity { 1.0f };
 };
 
 #endif // hifi_Camera_h

--- a/libraries/shared/src/shared/Camera.h
+++ b/libraries/shared/src/shared/Camera.h
@@ -123,7 +123,7 @@ public slots:
      * @function Camera.setCaptureMouse
      * @param {boolean} captureMouse - Whether or not to capture the mouse.
      */
-    void setCaptureMouse(bool captureMouse) { _captureMouse = captureMouse; }
+    void setCaptureMouse(bool captureMouse) { _captureMouse = captureMouse; emit captureMouseUpdated(captureMouse); }
 
     /**jsdoc
      * Computes a {@link PickRay} based on the current camera configuration and the specified <code>x, y</code> position on the 

--- a/libraries/shared/src/shared/Camera.h
+++ b/libraries/shared/src/shared/Camera.h
@@ -43,6 +43,7 @@ class Camera : public QObject {
     Q_PROPERTY(glm::quat orientation READ getOrientation WRITE setOrientation)
     Q_PROPERTY(QString mode READ getModeString WRITE setModeString NOTIFY modeUpdated)
     Q_PROPERTY(QVariantMap frustum READ getViewFrustum CONSTANT)
+    Q_PROPERTY(bool captureMouse READ getCaptureMouse WRITE setCaptureMouse NOTIFY captureMouseUpdated)
 
 public:
     Camera();
@@ -109,6 +110,20 @@ public slots:
      * @param {Quat} orientation - The orientation to set the camera to.
      */
     void setOrientation(const glm::quat& orientation);
+
+    /**jsdoc
+     * Gets the current mouse capture state.
+     * @function Camera.getMouseCapture
+     * @returns {boolean} The current mouse capture state.
+     */
+    bool getCaptureMouse() const { return _captureMouse; }
+
+    /**jsdoc
+     * Sets mouse capture state.
+     * @function Camera.setCaptureMouse
+     * @param {boolean} captureMouse - Whether or not to capture the mouse.
+     */
+    void setCaptureMouse(bool captureMouse) { _captureMouse = captureMouse; }
 
     /**jsdoc
      * Computes a {@link PickRay} based on the current camera configuration and the specified <code>x, y</code> position on the 
@@ -181,6 +196,20 @@ signals:
      */
     void modeUpdated(const QString& newMode);
 
+    /**jsdoc
+     * Triggered when the camera mouse capture state changes.
+     * @function Camera.captureMouseUpdated
+     * @param {boolean} newCaptureMouse - The new mouse capture state.
+     * @returns {Signal}
+     * @example <caption>Report mouse capture state changes.</caption>
+     * function onCaptureMouseUpdated(newCaptureMouse) {
+     *     print("The mouse capture has changed to " + newCaptureMouse);
+     * }
+     *
+     * Camera.captureMouseUpdated.connect(onCaptureMouseUpdated);
+     */
+    void captureMouseUpdated(bool newCaptureMouse);
+
 private:
     void recompose();
     void decompose();
@@ -194,6 +223,8 @@ private:
     glm::quat _orientation;
     bool _isKeepLookingAt{ false };
     glm::vec3 _lookingAt;
+
+    bool _captureMouse { false };
 };
 
 #endif // hifi_Camera_h

--- a/libraries/shared/src/shared/Camera.h
+++ b/libraries/shared/src/shared/Camera.h
@@ -3,6 +3,7 @@
 //  interface/src
 //
 //  Copyright 2013 High Fidelity, Inc.
+//  Copyright 2020 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -119,9 +120,9 @@ public slots:
     bool getCaptureMouse() const { return _captureMouse; }
 
     /**jsdoc
-     * Sets mouse capture state.
+     * Sets the mouse capture state.
      * @function Camera.setCaptureMouse
-     * @param {boolean} captureMouse - Whether or not to capture the mouse.
+     * @param {boolean} captureMouse - <code>true</code> to capture the mouse, <code>false</code> to release the mouse.
      */
     void setCaptureMouse(bool captureMouse) { _captureMouse = captureMouse; emit captureMouseUpdated(captureMouse); }
 

--- a/libraries/shared/src/shared/Camera.h
+++ b/libraries/shared/src/shared/Camera.h
@@ -44,7 +44,7 @@ class Camera : public QObject {
     Q_PROPERTY(glm::quat orientation READ getOrientation WRITE setOrientation)
     Q_PROPERTY(QString mode READ getModeString WRITE setModeString NOTIFY modeUpdated)
     Q_PROPERTY(QVariantMap frustum READ getViewFrustum CONSTANT)
-    Q_PROPERTY(bool captureMouse READ getCaptureMouse WRITE setCaptureMouse NOTIFY captureMouseUpdated)
+    Q_PROPERTY(bool captureMouse READ getCaptureMouse WRITE setCaptureMouse NOTIFY captureMouseChanged)
     Q_PROPERTY(float sensitivity READ getSensitivity WRITE setSensitivity)
 
 public:
@@ -115,31 +115,32 @@ public slots:
 
     /**jsdoc
      * Gets the current mouse capture state.
-     * @function Camera.getMouseCapture
-     * @returns {boolean} The current mouse capture state.
+     * @function Camera.getCaptureMouse
+     * @returns {boolean} <code>true</code> if the mouse is captured (is invisible and cannot leave the bounds of Interface,
+     * if Interface is the active window and no menu item is selected), <code>false</code> if the mouse is behaving normally.
      */
     bool getCaptureMouse() const { return _captureMouse; }
 
     /**jsdoc
-     * Sets the mouse capture state.  When <code>true</code>, the mouse will be invisible and cannot leave the bounds of
+     * Sets the mouse capture state.  When <code>true</code>, the mouse is invisible and cannot leave the bounds of
      * Interface, as long as Interface is the active window and no menu item is selected.  When <code>false</code>, the mouse
-     * will behave normally.
+     * behaves normally.
      * @function Camera.setCaptureMouse
      * @param {boolean} captureMouse - <code>true</code> to capture the mouse, <code>false</code> to release the mouse.
      */
-    void setCaptureMouse(bool captureMouse) { _captureMouse = captureMouse; emit captureMouseUpdated(captureMouse); }
+    void setCaptureMouse(bool captureMouse) { _captureMouse = captureMouse; emit captureMouseChanged(captureMouse); }
 
     /**jsdoc
      * Gets the current camera sensitivity.
      * @function Camera.getSensitivity
-     * @returns {boolean} The current camera sensitivity.
+     * @returns {number} The current camera sensitivity.  Must be positive.
      */
     float getSensitivity() const { return _sensitivity; }
 
     /**jsdoc
      * Sets the camera sensitivity.  Higher values mean that the camera will be more sensitive to mouse movements.
      * @function Camera.setSensitivity
-     * @param {boolean} sensitivity - The desired camera sensitivity.
+     * @param {number} sensitivity - The desired camera sensitivity.  Must be positive.
      */
     void setSensitivity(float sensitivity) { _sensitivity = glm::max(0.0f, sensitivity); }
 
@@ -216,17 +217,17 @@ signals:
 
     /**jsdoc
      * Triggered when the camera mouse capture state changes.
-     * @function Camera.captureMouseUpdated
+     * @function Camera.captureMouseChanged
      * @param {boolean} newCaptureMouse - The new mouse capture state.
      * @returns {Signal}
      * @example <caption>Report mouse capture state changes.</caption>
-     * function onCaptureMouseUpdated(newCaptureMouse) {
+     * function onCaptureMouseChanged(newCaptureMouse) {
      *     print("The mouse capture has changed to " + newCaptureMouse);
      * }
      *
-     * Camera.captureMouseUpdated.connect(onCaptureMouseUpdated);
+     * Camera.captureMouseChanged.connect(onCaptureMouseChanged);
      */
-    void captureMouseUpdated(bool newCaptureMouse);
+    void captureMouseChanged(bool newCaptureMouse);
 
 private:
     void recompose();


### PR DESCRIPTION
(Currently not hooked up to any scripts or keys)

To enable, in console: `Camera.captureMouse = true;`

Set to false to disable.

Needs to be tested on other OSes, and not sure how it interacts with the mouse logic in HMD