### PR TITLE
Add open-in-external-browser button to web browser dialog

### DIFF
--- a/interface/resources/qml/Browser.qml
+++ b/interface/resources/qml/Browser.qml
@@ -64,7 +64,7 @@ ScrollingWindow {
             id: buttons
             spacing: 4
             anchors.top: parent.top
-            anchors.topMargin: 8
+            anchors.topMargin: 4
             anchors.left: parent.left
             anchors.leftMargin: 8
             HiFiGlyphs {
@@ -115,7 +115,7 @@ ScrollingWindow {
             id: border
             height: 48
             anchors.top: parent.top
-            anchors.topMargin: 8
+            anchors.topMargin: 4
             anchors.right: parent.right
             anchors.rightMargin: 8
             anchors.left: buttons.right
@@ -158,7 +158,7 @@ ScrollingWindow {
             TextField {
                 id: addressBar
                 anchors.right: externalBrowser.left
-                anchors.rightMargin: 8
+                anchors.rightMargin: 32
                 anchors.left: barIcon.right
                 anchors.leftMargin: 0
                 anchors.verticalCenter: parent.verticalCenter
@@ -255,7 +255,7 @@ ScrollingWindow {
             parentRoot: root
 
             anchors.top: buttons.bottom
-            anchors.topMargin: 8
+            anchors.topMargin: 4
             anchors.bottom: parent.bottom
             anchors.left: parent.left
             anchors.right: parent.right

--- a/interface/resources/qml/Browser.qml
+++ b/interface/resources/qml/Browser.qml
@@ -62,37 +62,43 @@ ScrollingWindow {
             anchors.left: parent.left
             anchors.leftMargin: 8
             HiFiGlyphs {
-                id: back;
+                id: back
                 enabled: webview.canGoBack
                 text: hifi.glyphs.backward
-                color: enabled ? hifi.colors.faintGray : hifi.colors.lightGray
+                color: enabled ? (backMouseArea.containsMouse ? hifi.colors.blueHighlight : hifi.colors.faintGray) : hifi.colors.lightGray
                 size: 48
                 MouseArea {
+                    id: backMouseArea
                     anchors.fill: parent
+                    hoverEnabled: true
                     onClicked: webview.goBack();
                 }
             }
 
             HiFiGlyphs {
-                id: forward;
+                id: forward
                 enabled: webview.canGoForward
                 text: hifi.glyphs.forward
-                color: enabled ? hifi.colors.faintGray : hifi.colors.lightGray
+                color: enabled ? (forwardMouseArea.containsMouse ? hifi.colors.blueHighlight : hifi.colors.faintGray) : hifi.colors.lightGray
                 size: 48
                 MouseArea {
+                    id: forwardMouseArea
                     anchors.fill: parent
+                    hoverEnabled: true
                     onClicked: webview.goForward();
                 }
             }
 
             HiFiGlyphs {
-                id: reload;
+                id: reload
                 enabled: url !== ""
                 text: webview.loading ? hifi.glyphs.close : hifi.glyphs.reload
-                color: enabled ? hifi.colors.faintGray : hifi.colors.lightGray
+                color: enabled ? (reloadMouseArea.containsMouse ? hifi.colors.blueHighlight : hifi.colors.faintGray) : hifi.colors.lightGray
                 size: 48
                 MouseArea {
+                    id: reloadMouseArea
                     anchors.fill: parent
+                    hoverEnabled: true
                     onClicked: webview.loading ? webview.stop() : webview.reload();
                 }
             }

--- a/interface/resources/qml/Browser.qml
+++ b/interface/resources/qml/Browser.qml
@@ -165,22 +165,32 @@ ScrollingWindow {
                 focus: true
                 colorScheme: hifi.colorSchemes.dark
                 placeholderText: "Enter URL"
+                inputMethodHints: Qt.ImhUrlCharactersOnly
                 Component.onCompleted: ScriptDiscoveryService.scriptsModelFilter.filterRegExp = new RegExp("^.*$", "i")
                 Keys.onPressed: {
                     switch(event.key) {
                         case Qt.Key_Enter:
                         case Qt.Key_Return:
                             event.accepted = true
-                            if (text.indexOf("http") != 0) {
+                            if (text.indexOf("http") !== 0) {
                                 text = "http://" + text;
                             }
+
+                            // Setting webiew.url directly doesn't add the URL to the navigation history.
+                            //webview.url = text;
+                            // The following works around this bug.
+                            text = encodeURI(text);
+                            text = text.replace(/;/g, "%3b");  // Prevent script injection.
+                            text = text.replace(/'/g, "%25");  // ""
+                            webview.runJavaScript("window.location='" + text + "'");
+
                             root.hidePermissionsBar();
                             root.keyboardRaised = false;
-                            webview.url = text;
                             break;
                     }
                 }
             }
+
         }
 
         Rectangle {
@@ -257,7 +267,7 @@ ScrollingWindow {
     Keys.onPressed: {
         switch(event.key) {
             case Qt.Key_L:
-                if (event.modifiers == Qt.ControlModifier) {
+                if (event.modifiers === Qt.ControlModifier) {
                     event.accepted = true
                     addressBar.selectAll()
                     addressBar.forceActiveFocus()
@@ -265,4 +275,5 @@ ScrollingWindow {
                 break;
         }
     }
+
 } // dialog

--- a/interface/resources/qml/Browser.qml
+++ b/interface/resources/qml/Browser.qml
@@ -63,29 +63,38 @@ ScrollingWindow {
             anchors.leftMargin: 8
             HiFiGlyphs {
                 id: back;
-                enabled: webview.canGoBack;
+                enabled: webview.canGoBack
                 text: hifi.glyphs.backward
-                color: enabled ? hifi.colors.text : hifi.colors.disabledText
+                color: enabled ? hifi.colors.faintGray : hifi.colors.lightGray
                 size: 48
-                MouseArea { anchors.fill: parent;  onClicked: webview.goBack() }
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: webview.goBack();
+                }
             }
 
             HiFiGlyphs {
                 id: forward;
-                enabled: webview.canGoForward;
+                enabled: webview.canGoForward
                 text: hifi.glyphs.forward
-                color: enabled ? hifi.colors.text : hifi.colors.disabledText
+                color: enabled ? hifi.colors.faintGray : hifi.colors.lightGray
                 size: 48
-                MouseArea { anchors.fill: parent;  onClicked: webview.goForward() }
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: webview.goForward();
+                }
             }
 
             HiFiGlyphs {
                 id: reload;
-                enabled: webview.canGoForward;
+                enabled: url !== ""
                 text: webview.loading ? hifi.glyphs.close : hifi.glyphs.reload
-                color: enabled ? hifi.colors.text : hifi.colors.disabledText
+                color: enabled ? hifi.colors.faintGray : hifi.colors.lightGray
                 size: 48
-                MouseArea { anchors.fill: parent;  onClicked: webview.goForward() }
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: webview.loading ? webview.stop() : webview.reload();
+                }
             }
 
         }
@@ -105,11 +114,12 @@ ScrollingWindow {
                 width: parent.height
                 height: parent.height
                 Image {
-                    source: webview.icon;
+                    source: webview.icon
                     x: (parent.height - height) / 2
                     y: (parent.width - width) / 2
-                    sourceSize: Qt.size(width, height);
-                    verticalAlignment: Image.AlignVCenter;
+                    width: 28
+                    height: 28
+                    verticalAlignment: Image.AlignVCenter
                     horizontalAlignment: Image.AlignHCenter
                 }
             }

--- a/interface/resources/qml/Browser.qml
+++ b/interface/resources/qml/Browser.qml
@@ -49,6 +49,12 @@ ScrollingWindow {
         desktop.setAutoAdd(auto);
     }
 
+    function openExternalBrowser() {
+        Qt.openUrlExternally(addressBar.text);
+        root.shown = false;
+        root.windowClosed();
+    }
+
     Item {
         id:item
         width: pane.contentWidth
@@ -115,6 +121,25 @@ ScrollingWindow {
             anchors.left: buttons.right
             anchors.leftMargin: 8
     
+            HiFiGlyphs {
+                id: externalBrowser
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.topMargin: 4
+                enabled: !HMD.active && url !== ""
+                font.family: "FontAwesome"
+                text: "\uf24d"
+                rotation: -90
+                color: enabled ? (externalBrowserMouseArea.containsMouse ? hifi.colors.blueHighlight : hifi.colors.faintGray) : hifi.colors.lightGray
+                size: 32
+                MouseArea {
+                    id: externalBrowserMouseArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: openExternalBrowser();
+                }
+            }
+
             Item {
                 id: barIcon
                 width: parent.height
@@ -132,7 +157,7 @@ ScrollingWindow {
 
             TextField {
                 id: addressBar
-                anchors.right: parent.right
+                anchors.right: externalBrowser.left
                 anchors.rightMargin: 8
                 anchors.left: barIcon.right
                 anchors.leftMargin: 0

--- a/interface/resources/qml/Browser.qml
+++ b/interface/resources/qml/Browser.qml
@@ -145,7 +145,7 @@ ScrollingWindow {
                 width: parent.height
                 height: parent.height
                 Image {
-                    source: webview.icon
+                    source: webview.loading ? "" : webview.icon
                     x: (parent.height - height) / 2
                     y: (parent.width - width) / 2
                     width: 28


### PR DESCRIPTION
Adds a button to the right of the URL box that opens the URL in an external browser, and closes the Interface browser window. This button is only enabled in desktop mode.

![browser-window](https://user-images.githubusercontent.com/7455448/92322459-6a1fb180-f085-11ea-962a-249d05f838c4.png)

Also:
- Fixes colors of prev, next, and stop/reload buttons so that they're visible.
- Fixes action of stop/reload button.
- Fixes display of Web page's favicon.
- Adds hover action to prev, next, and stop/reload buttons.
- Fixes (works around bug in) location history: when you manually type in a new URL the location history is updated (and prev/next buttons work) rather than it only working when clicking on links in the Web page.
