### PR TITLE
Fix pick rays not intersecting glTF models

### DIFF
--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -1019,7 +1019,9 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
 
             hfmModel.meshes.append(HFMMesh());
             HFMMesh& mesh = hfmModel.meshes[hfmModel.meshes.size() - 1];
-            if (!hfmModel.hasSkeletonJoints) { 
+            mesh.modelTransform = globalTransforms[nodeIndex];
+
+            if (!hfmModel.hasSkeletonJoints) {
                 HFMCluster cluster;
                 cluster.jointIndex = nodecount;
                 cluster.inverseBindMatrix = glm::mat4();


### PR DESCRIPTION
This PR fixes the problem of pick rays not intersecting many glTF entities.