### PR TITLE
Fix audio output switching crash

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -2072,13 +2072,14 @@ bool AudioClient::switchOutputToAudioDevice(const HifiAudioDeviceInfo outputDevi
     // NOTE: device start() uses the Qt internal device list
     Lock lock(_deviceMutex);
 
-    Lock localAudioLock(_localAudioMutex);
     _localSamplesAvailable.exchange(0, std::memory_order_release);
 
     //wait on local injectors prep to finish running
     if ( !_localPrepInjectorFuture.isFinished()) {
         _localPrepInjectorFuture.waitForFinished();
     }
+
+    Lock localAudioLock(_localAudioMutex);
 
     // cleanup any previously initialized device
     if (_audioOutput) {


### PR DESCRIPTION
Fix double locking attempt if waitForFinished causes prepareLocalAudioInjectors to be called on this thread.

Co-Authored-By: Heather Anderson <1115056+odysseus654@users.noreply.github.com>