### PR TITLE
Fix "Serverless" capitalization in title bar

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -7110,9 +7110,9 @@ void Application::updateWindowTitle() const {
     QString currentPlaceName;
     if (isServerlessMode()) {
         if (isInErrorState) {
-            currentPlaceName = "serverless: " + nodeList->getDomainHandler().getErrorDomainURL().toString();
+            currentPlaceName = "Serverless: " + nodeList->getDomainHandler().getErrorDomainURL().toString();
         } else {
-            currentPlaceName = "serverless: " + DependencyManager::get<AddressManager>()->getDomainURL().toString();
+            currentPlaceName = "Serverless: " + DependencyManager::get<AddressManager>()->getDomainURL().toString();
         }
     } else {
         currentPlaceName = DependencyManager::get<AddressManager>()->getDomainURL().host();


### PR DESCRIPTION
If you're on a serverless domain, the Interface title bar currently starts with "serverless:". This PR fixes this so that it reads "Serverless:".

![serverless-title-bar](https://user-images.githubusercontent.com/7455448/93163994-9a91da80-f76c-11ea-9389-2e9f576bd87c.png)
