### PR TITLE
Sanitize URLs in ExternalResources

### DIFF
--- a/libraries/networking/src/ExternalResource.h
+++ b/libraries/networking/src/ExternalResource.h
@@ -85,19 +85,24 @@ public:
     /**
      * Returns the location of a resource as a QUrl
      *
-     * Returns the location of the resource \p relative_path in bucket \p bucket
+     * Returns the location of the resource \p path in bucket \p bucket
      *
      * @note The resulting path will be sanitized by condensing multiple instances of '/' to one.
      * This is done for easier usage with Amazon S3 and compatible systems.
+     *
+     * @par It will also convert all paths into relative ones respect to the bucket.
+     *
+     * @warning This function should only be given paths with a domain name. If given a complete path,
+     * it will emit a warning into the log and return the unmodified path it was given.
      *
      * @param bucket The bucket in which the resource is found
      * @param relative_path The path of the resource within the bucket
      * @returns The resulting URL as a QUrl
      */
-    QUrl getQUrl(Bucket bucket, const QUrl& path);
+    QUrl getQUrl(Bucket bucket, QString path);
 
-    QString getUrl(Bucket bucket, const QString& path) {
-       return ExternalResource::getQUrl(bucket, QUrl(path)).toString();
+    QString getUrl(Bucket bucket, QString path) {
+       return ExternalResource::getQUrl(bucket, path).toString();
     };
 
     /**

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -693,8 +693,7 @@ public:
      * @param {string} path - The path within the external resource bucket where the asset is located. 
      *     <p>Normally, this should start with a path or filename to be appended to the bucket URL.
      *     Alternatively, it can be a relative path starting with <code>./</code> or <code>../</code>, to navigate within the 
-     *     resource bucket's URL. Or it can be an absolute path starting with <code>/</code>, in which case the bucket's path
-     *     is discarded when calculating the asset's URL.</p>
+     *     resource bucket's URL.</p>
      * @Returns {string} The URL of an external asset.
      * @example <caption>Report the URL of a default particle.</caption>
      * print(Script.getExternalPath(Script.ExternalPaths.Assets, "Bazaar/Assets/Textures/Defaults/Interface/default_particle.png"));

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -240,7 +240,7 @@ public:
      * @param {object} enum - Enum.
      * @deprecated This function is deprecated and will be removed.
      */
-    // WARNING: This function must be called after a registerGlobalObject that creates the namespace this enum is located in, or\
+    // WARNING: This function must be called after a registerGlobalObject that creates the namespace this enum is located in, or
     // the globalObject won't function. E.g., if you have a Foo object and a Foo.FooType enum, Foo must be registered first.
     /// registers a global enum
     Q_INVOKABLE void registerEnum(const QString& enumName, QMetaEnum newEnum);


### PR DESCRIPTION
* Remove leading slashes, so that the path included in the bucket's path can't be overriden
* Remove any duplicated slashes always
* Small warning fix -- multiline comment

