### PR TITLE
Fix more warnings

### DIFF
--- a/libraries/entities-renderer/src/RenderableGizmoEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableGizmoEntityItem.h
@@ -29,7 +29,7 @@ protected:
     bool isTransparent() const override;
 
 private:
-    virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity);
+    virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;
     virtual void doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) override;
     virtual void doRender(RenderArgs* args) override;
 

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -1628,7 +1628,6 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
 
             // Mesh extents must be at least a minimum size, in particular for blendshapes to work on planar meshes.
             const float MODEL_MIN_DIMENSION = 0.001f;
-            auto x = EPSILON;
             auto delta = glm::max(glm::vec3(MODEL_MIN_DIMENSION) - mesh.meshExtents.size(), glm::vec3(0.0f)) / 2.0f;
             mesh.meshExtents.minimum -= delta;
             mesh.meshExtents.maximum += delta;


### PR DESCRIPTION
Fix more warnings in the Linux build process.

This one is quite trivial -- it adds a missing override, and removes an unused variable. There's still a few more to go, but the build is almost clean now!
