### PR TITLE
Set GL preference to GLVND

### DIFF
--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -238,6 +238,8 @@ target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_BINARY_DIR}/libraries
 target_openssl()
 
 target_bullet()
+
+set(OpenGL_GL_PREFERENCE "GLVND")
 target_opengl()
 add_crashpad()
 target_breakpad()

--- a/libraries/display-plugins/CMakeLists.txt
+++ b/libraries/display-plugins/CMakeLists.txt
@@ -13,6 +13,7 @@ include_hifi_library_headers(ktx)
 include_hifi_library_headers(render)
 include_hifi_library_headers(procedural)
 
+set(OpenGL_GL_PREFERENCE "GLVND")
 target_opengl()
 
 GroupSources("src/display-plugins")

--- a/libraries/gl/CMakeLists.txt
+++ b/libraries/gl/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(TARGET_NAME gl)
 setup_hifi_library(Gui Widgets)
 link_hifi_libraries(shared)
+
+set(OpenGL_GL_PREFERENCE "GLVND")
 target_opengl()
 

--- a/libraries/gpu-gl-common/CMakeLists.txt
+++ b/libraries/gpu-gl-common/CMakeLists.txt
@@ -2,5 +2,7 @@ set(TARGET_NAME gpu-gl-common)
 setup_hifi_library(Concurrent)
 link_hifi_libraries(shared gl gpu shaders)
 GroupSources("src")
+
+set(OpenGL_GL_PREFERENCE "GLVND")
 target_opengl()
 

--- a/libraries/gpu-gl/CMakeLists.txt
+++ b/libraries/gpu-gl/CMakeLists.txt
@@ -5,5 +5,7 @@ if (UNIX)
     target_link_libraries(${TARGET_NAME} pthread)
 endif(UNIX)
 GroupSources("src")
+
+set(OpenGL_GL_PREFERENCE "GLVND")
 target_opengl()
 

--- a/libraries/qml/CMakeLists.txt
+++ b/libraries/qml/CMakeLists.txt
@@ -3,4 +3,5 @@ setup_hifi_library(Multimedia Network Qml Quick WebChannel WebSockets ${PLATFORM
 link_hifi_libraries(shared networking gl)
 
 # Required for some low level GL interaction in the OffscreenQMLSurface
+set(OpenGL_GL_PREFERENCE "GLVND")
 target_opengl()

--- a/libraries/ui/CMakeLists.txt
+++ b/libraries/ui/CMakeLists.txt
@@ -4,4 +4,5 @@ link_hifi_libraries(shared networking qml gl audio audio-client plugins pointers
 include_hifi_library_headers(controllers)
 
 # Required for some low level GL interaction in the OffscreenQMLSurface
+set(OpenGL_GL_PREFERENCE "GLVND")
 target_opengl()

--- a/tools/gpu-frame-player/CMakeLists.txt
+++ b/tools/gpu-frame-player/CMakeLists.txt
@@ -21,6 +21,8 @@ link_hifi_libraries(
 )
 
 target_compile_definitions(${TARGET_NAME} PRIVATE USE_GL)
+
+set(OpenGL_GL_PREFERENCE "GLVND")
 target_opengl()
 #target_vulkan()
 


### PR DESCRIPTION
This should be a no-op, besides generating less build warnings,
since:

"CMake 3.11 and above prefer to choose GLVND libraries."

And 3.11 is a few years old at this point, so this is almost certainly what everyone is building with anyway.

This fixes a bunch of these:

```
CMake Warning (dev) at /usr/share/cmake/Modules/FindOpenGL.cmake:305 (message):
  Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when
  available.  Run "cmake --help-policy CMP0072" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  FindOpenGL found both a legacy GL library:

    OPENGL_gl_LIBRARY: /usr/lib64/libGL.so

  and GLVND libraries for OpenGL and GLX:

    OPENGL_opengl_LIBRARY: /usr/lib64/libOpenGL.so
    OPENGL_glx_LIBRARY: /usr/lib64/libGLX.so

  OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
  compatibility with CMake 3.10 and below the legacy GL library will be used.
Call Stack (most recent call first):
  /home/dale/git/vircadia/vcpkg/bd824a32/scripts/buildsystems/vcpkg.cmake:262 (_find_package)
  cmake/macros/TargetGlad.cmake:19 (find_package)
  cmake/macros/TargetOpenGL.cmake:9 (target_glad)
  tools/gpu-frame-player/CMakeLists.txt:28 (target_opengl)
This warning is for project developers.  Use -Wno-dev to suppress it.
```