### PR TITLE
Fix handling of missing glTF blendshape target meshes

### DIFF
--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -1586,12 +1586,16 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                         int targetIndex = weightedIndex;
                         hfmModel.blendshapeChannelNames.push_back("target_" + QString::number(weightedIndex));
 
-                        if (!names.isEmpty() && names.contains(keys[weightedIndex])) {
+                        if (!names.isEmpty()) {
                             targetIndex = names.indexOf(keys[weightedIndex]);
+                            if (targetIndex == -1) {
+                                continue;  // Ignore blendshape targets not present in glTF file.
+                            }
                             indexFromMapping = values[weightedIndex].first;
                             weight = values[weightedIndex].second;
                             hfmModel.blendshapeChannelNames[weightedIndex] = keys[weightedIndex];
                         }
+
                         HFMBlendshape& blendshape = mesh.blendshapes[indexFromMapping];
                         auto target = primitive.targets[targetIndex];
 


### PR DESCRIPTION
If a glTF (.glTF or .glb) model has a blendshape with a target mesh missing, this can can result in crosslinking of blendshapes (the blendshape value affects an unintended mesh) or an Interface crash when the model is loaded.

Repro: Using current release or master, rez the following model: http://ctrlaltstudio.com/downloads/vircadia-dev/gltf/hapticMale/hapticMale.glb
Then clear cache content (Developer > Network > Clear Disk Cache) and restart Interface, and repeat. You'll occasionally have Interface crash at start-up.

Testing:
- This PR should not crash at start-up because of that model.
- Blendshapes should still work. For example, using the following code in the JavaScript console should open and close the avatar's mouth per the blendshape value. (Edit the UUID to be that of the entity rezzed.)
```
Entities.editEntity("{00000000-0000-0000-0000-000000000000}", { blendshapeCoefficients: JSON.stringify({ "JawOpen": 1.0 })});
```
- Blendshapes on glTF avatars should still work (e.g., mouth open and close as you speak).
