### PR TITLE
Open chat hyperlinks in Interface browser window

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
         "ecmaVersion": 5
     },
     "globals": {
+        "About": false,
         "Account": false,
         "Agent": false,
         "AnimationCache": false,

--- a/interface/src/AboutUtil.cpp
+++ b/interface/src/AboutUtil.cpp
@@ -45,6 +45,16 @@ QString AboutUtil::getQtVersion() const {
 }
 
 void AboutUtil::openUrl(const QString& url) const {
+    auto abboutUtilInstance = AboutUtil::getInstance();
+    if (!abboutUtilInstance) {
+        return;
+    }
+
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(abboutUtilInstance, "openUrl", Q_ARG(const QString&, url));
+        return;
+    }
+
     auto tablet = DependencyManager::get<TabletScriptingInterface>()->getTablet("com.highfidelity.interface.tablet.system");
     auto hmd = DependencyManager::get<HMDScriptingInterface>();
     auto offscreenUi = DependencyManager::get<OffscreenUi>();

--- a/interface/src/AboutUtil.h
+++ b/interface/src/AboutUtil.h
@@ -79,7 +79,7 @@ public:
 public slots:
 
     /**jsdoc
-     * Display a web page in an Interface browser window.
+     * Display a web page in an Interface browser window or the tablet.
      * @function About.openUrl
      * @param {string} url - The URL of the web page you want to view in Interface.
      */

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -645,12 +645,16 @@ void WindowScriptingInterface::setActiveDisplayPlugin(int index) {
     qApp->setActiveDisplayPlugin(name);
 }
 
-void WindowScriptingInterface::openWebBrowser() {
+void WindowScriptingInterface::openWebBrowser(const QString& url) {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "openWebBrowser", Qt::QueuedConnection);
+        QMetaObject::invokeMethod(this, "openWebBrowser", Q_ARG(const QString&, url));
         return;
     }
-
+    
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    offscreenUi->load("Browser.qml");
+    offscreenUi->load("Browser.qml", [=](QQmlContext* context, QObject* newObject) {
+        if (!url.isEmpty()) {
+            newObject->setProperty("url", url);
+        }
+    });
 }

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -650,7 +650,7 @@ void WindowScriptingInterface::openWebBrowser(const QString& url) {
         QMetaObject::invokeMethod(this, "openWebBrowser", Q_ARG(const QString&, url));
         return;
     }
-    
+
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
     offscreenUi->load("Browser.qml", [=](QQmlContext* context, QObject* newObject) {
         if (!url.isEmpty()) {

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -618,7 +618,7 @@ public slots:
     /**jsdoc
      * Opens an Interface web browser window.
      * @function Window.openWebBrowser
-     * @param {string} url="" - The URL of the web page to display.
+     * @param {string} [url=""] - The URL of the web page to display.
      */
     void openWebBrowser(const QString& url = "");
 

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -616,10 +616,11 @@ public slots:
     void setActiveDisplayPlugin(int index);
 
     /**jsdoc
-     * Opens a web browser in a pop-up window.
+     * Opens an Interface web browser window.
      * @function Window.openWebBrowser
+     * @param {string} url="" - The URL of the web page to display.
      */
-    void openWebBrowser();
+    void openWebBrowser(const QString& url = "");
 
 
 private slots:

--- a/scripts/communityScripts/chat/FloofChat.js
+++ b/scripts/communityScripts/chat/FloofChat.js
@@ -322,7 +322,7 @@ function onWebEventReceived(event) {
             gotoConfirm(event.url);
         }
         if (event.cmd === "URL") {
-            About.openUrl(event.url);
+            Window.openWebBrowser(event.url);
         }
         if (event.cmd === "EXTERNALURL") {
             Window.openUrl(event.url);

--- a/scripts/communityScripts/chat/FloofChat.js
+++ b/scripts/communityScripts/chat/FloofChat.js
@@ -322,13 +322,7 @@ function onWebEventReceived(event) {
             gotoConfirm(event.url);
         }
         if (event.cmd === "URL") {
-            new OverlayWebWindow({
-                title: 'Web',
-                source: event.url,
-                width: 900,
-                height: 700,
-                visible: true
-            });
+            About.openUrl(event.url);
         }
         if (event.cmd === "EXTERNALURL") {
             Window.openUrl(event.url);


### PR DESCRIPTION
Chat hypelinks are opened in an Interface browser window rather than a custom window (without address bar etc. controls).

Also:
- Adds an optional URL parameter to `Windows.openWebBrowser()`.
- Fixes an Interface crash in `About.openUrl()`.
- Adds the `About` API to ESLint list of known globals.
- Minor update to `About.openUrl()` JSDoc.

@FluffyJenkins 