### PR TITLE
Improve logging: color, ms timestamps, PID, thread id via environment variable

### DIFF
--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -51,7 +51,7 @@ LogHandler::LogHandler() {
 
     auto optionList = logOptions.split(",");
 
-    for(auto option : optionList) {
+    for (auto option : optionList) {
         option = option.trimmed();
 
         if (option == "color") {

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -57,7 +57,7 @@ public:
     void setupRepeatedMessageFlusher();
 
 private:
-    LogHandler() = default;
+    LogHandler();
     ~LogHandler() = default;
 
     void flushRepeatedMessages();
@@ -66,6 +66,7 @@ private:
     bool _shouldOutputProcessID { false };
     bool _shouldOutputThreadID { false };
     bool _shouldDisplayMilliseconds { false };
+    bool _useColor { false };
 
     int _currentMessageID { 0 };
     struct RepeatedMessageRecord {


### PR DESCRIPTION
This patch exposes some features of the logging system that were only available by tweaking the code, and adds the ability to use ANSI color, which seems to be available on all systems (Windows appears to have also added it).

This should make interesting messages much more distinctive. Example with color and milliseconds enabled:

![Screenshot_20201012_174601](https://user-images.githubusercontent.com/51060919/95765997-ecb61500-0cb2-11eb-8644-dcc315170328.png)

### Usage

Set `VIRCADIA_LOG_OPTIONS` to a string containing these keywords:

* color
* milliseconds
* process_id
* thread_id

Multiple options are comma separated. Example:

    $ export VIRCADIA_LOG_OPTIONS="color,milliseconds"


