### PR TITLE
Workaround: Add Valve Index to calibratable devices

### DIFF
--- a/interface/resources/qml/hifi/tablet/ControllerSettings.qml
+++ b/interface/resources/qml/hifi/tablet/ControllerSettings.qml
@@ -244,7 +244,7 @@ Item {
                     source: InputConfiguration.configurationLayout(box.textAt(box.currentIndex));
                     onLoaded: {
                         if (loader.item.hasOwnProperty("pluginName")) {
-                            if (box.textAt(box.currentIndex) === "HTC Vive") {
+                            if (box.textAt(box.currentIndex) === "HTC Vive" || box.textAt(box.currentIndex) === "Valve Index" || box.textAt(box.currentIndex) === "Valve HMD" || box.textAt(box.currentIndex) === "Valve") {
                                 loader.item.pluginName = "OpenVR";
                             } else {
                                 loader.item.pluginName = box.textAt(box.currentIndex);
@@ -298,7 +298,7 @@ Item {
                 loader.source = "";
                 var selectedDevice = box.textAt(box.currentIndex);
                 var source = "";
-                if (selectedDevice == "HTC Vive") {
+                if (selectedDevice == "HTC Vive" || selectedDevice == "Valve Index" || selectedDevice == "Valve HMD" || selectedDevice == "Valve") {
                     source = InputConfiguration.configurationLayout("OpenVR");
                 } else {
                     source = InputConfiguration.configurationLayout(selectedDevice);

--- a/interface/resources/qml/hifi/tablet/ControllerSettings.qml
+++ b/interface/resources/qml/hifi/tablet/ControllerSettings.qml
@@ -27,6 +27,7 @@ Item {
     width: parent.width
 
     property string title: "Controls"
+    property var openVRDevices: ["HTC Vive", "Valve Index", "Valve HMD", "Valve"]
 
     HifiConstants { id: hifi }
 
@@ -244,7 +245,7 @@ Item {
                     source: InputConfiguration.configurationLayout(box.textAt(box.currentIndex));
                     onLoaded: {
                         if (loader.item.hasOwnProperty("pluginName")) {
-                            if (box.textAt(box.currentIndex) === "HTC Vive" || box.textAt(box.currentIndex) === "Valve Index" || box.textAt(box.currentIndex) === "Valve HMD" || box.textAt(box.currentIndex) === "Valve") {
+                            if (openVRDevices.indexOf(box.textAt(box.currentIndex)) !== -1) {
                                 loader.item.pluginName = "OpenVR";
                             } else {
                                 loader.item.pluginName = box.textAt(box.currentIndex);
@@ -298,7 +299,7 @@ Item {
                 loader.source = "";
                 var selectedDevice = box.textAt(box.currentIndex);
                 var source = "";
-                if (selectedDevice == "HTC Vive" || selectedDevice == "Valve Index" || selectedDevice == "Valve HMD" || selectedDevice == "Valve") {
+                if (openVRDevices.indexOf(selectedDevice) !== -1) {
                     source = InputConfiguration.configurationLayout("OpenVR");
                 } else {
                     source = InputConfiguration.configurationLayout(selectedDevice);


### PR DESCRIPTION
This enables the calibration for Vive Trackers on the Valve Index. I tested this on Debian Testing:
https://data.moto9000.moe/vircadia/%23808/tracker.webm
This should be done different as most HMDs can be used via OpenVR and could also be used with Vive Trackers because of that.