### PR TITLE
Rename field in Explore app's "add location" dialog

### DIFF
--- a/scripts/communityScripts/explore/explore.html
+++ b/scripts/communityScripts/explore/explore.html
@@ -43,7 +43,7 @@
                                     lazy-validation>
                                 <v-row>
                                     <v-col cols="12" sm="6" md="4">
-                                        <v-text-field v-model="domainName" :rules="domainNameRules" label="Domain Display Name *" required hint="This is the name that shows on the listing" persistent-hint></v-text-field>
+                                        <v-text-field v-model="domainName" :rules="domainNameRules" label="Location Name *" required hint="This is the name that shows on the listing" persistent-hint></v-text-field>
                                     </v-col>
                                     <v-col cols="12" sm="6" md="4">
                                         <v-text-field v-model="owner" :rules="ownerRules" label="Owner *" hint="Owner name to show in listing" required persistent-hint></v-text-field>

--- a/scripts/communityScripts/explore/explore.js
+++ b/scripts/communityScripts/explore/explore.js
@@ -2,9 +2,7 @@
 //
 //  Created by Darlingnotin in 2019.
 //  Copyright 2019 Darlingnotin
-//
-//  App maintained in: https://github.com/kasenvr/Decentralized_GoTo_Experimental
-//  App copied to: https://github.com/kasenvr/project-athena
+//  Copyright 2020 Vircadia contributors.
 //
 //  Distributed under the ISC license.
 //  See the accompanying file LICENSE or https://opensource.org/licenses/ISC


### PR DESCRIPTION
The name field's label has been changed from "Domain Display Name" to "Location Name".