### PR TITLE
Hide "Secure Transactions" section in Settings > Security

### DIFF
--- a/interface/resources/qml/hifi/dialogs/security/Security.qml
+++ b/interface/resources/qml/hifi/dialogs/security/Security.qml
@@ -333,6 +333,8 @@ Rectangle {
             anchors.left: parent.left;
             anchors.right: parent.right;
             height: childrenRect.height;
+            // FIXME: Reuse or remove wallet-related code.
+            visible: false
 
             Rectangle {
                 id: walletHeaderContainer;


### PR DESCRIPTION
In the Settings > Security dialog there is no longer a "Secure Transactions" section saying that your wallet is not set up and to open the Inventory app to get started.

This PR just hides this part of the dialog so that it is not displayed; no other code is changed.