### PR TITLE
Prevent crash on entity-script-server due to logging interface.

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -130,12 +130,7 @@ static QScriptValue debugPrint(QScriptContext* context, QScriptEngine* engine) {
     // This message was sent by one of our script engines, let's try to see if we can find the source.
     // Note that the first entry in the backtrace should be "print" and is somewhat useless to us
     AbstractLoggerInterface* loggerInterface = AbstractLoggerInterface::get();
-    if (!loggerInterface) {
-        qCDebug(scriptengine_script, "%s", qUtf8Printable(message));
-        return QScriptValue();
-    }
-
-    if (loggerInterface->showSourceDebugging()) {
+    if (loggerInterface && loggerInterface->showSourceDebugging()) {
         QScriptContext* userContext = context;
         while (userContext && QScriptContextInfo(userContext).functionType() == QScriptContextInfo::NativeFunction) {
             userContext = userContext->parentContext();

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -130,6 +130,11 @@ static QScriptValue debugPrint(QScriptContext* context, QScriptEngine* engine) {
     // This message was sent by one of our script engines, let's try to see if we can find the source.
     // Note that the first entry in the backtrace should be "print" and is somewhat useless to us
     AbstractLoggerInterface* loggerInterface = AbstractLoggerInterface::get();
+    if (!loggerInterface) {
+        qCDebug(scriptengine_script, "%s", qUtf8Printable(message));
+        return QScriptValue();
+    }
+
     if (loggerInterface->showSourceDebugging()) {
         QScriptContext* userContext = context;
         while (userContext && QScriptContextInfo(userContext).functionType() == QScriptContextInfo::NativeFunction) {


### PR DESCRIPTION
I've confirmed this fixes the issue.

However, the original issue was reported by Twa_hinkle.

To test: Ensure the entity script server does not crash for any reason on start. An easy provable test is to add the Explore beacon to your domain and ensure the entity server script runs. Confirm your domain hows up in the Explore list.