### PR TITLE
ScriptCache: add local file change detection

### DIFF
--- a/libraries/networking/src/FileResourceRequest.cpp
+++ b/libraries/networking/src/FileResourceRequest.cpp
@@ -13,6 +13,7 @@
 
 #include <QtCore/QFile>
 #include <QtCore/QFileSelector>
+#include <QtCore/QDateTime>
 #include <QtCore/QDebug>
 
 #include <StatTracker.h>
@@ -54,6 +55,7 @@ void FileResourceRequest::doSend() {
     } else {
         QFile file(filename);
         if (file.exists()) {
+            setProperty("last-modified", toHttpDateString(QFileInfo(file).lastModified().toMSecsSinceEpoch()));
             if (file.open(QFile::ReadOnly)) {
 
                 if (file.size() < _byteRange.fromInclusive || file.size() < _byteRange.toExclusive) {

--- a/libraries/networking/src/ResourceRequest.cpp
+++ b/libraries/networking/src/ResourceRequest.cpp
@@ -15,8 +15,14 @@
 #include <DependencyManager.h>
 #include <StatTracker.h>
 
+#include <QtCore/QDateTime>
 #include <QtCore/QThread>
 
+QString ResourceRequest::toHttpDateString(uint64_t msecsSinceEpoch) {
+    return QLocale::c()
+        .toString(QDateTime::fromMSecsSinceEpoch(msecsSinceEpoch), QLatin1String("ddd, dd MMM yyyy hh:mm:ss 'GMT'"))
+        .toLatin1();
+}
 
 void ResourceRequest::send() {
     if (QThread::currentThread() != thread()) {

--- a/libraries/networking/src/ResourceRequest.cpp
+++ b/libraries/networking/src/ResourceRequest.cpp
@@ -19,8 +19,8 @@
 #include <QtCore/QThread>
 
 QString ResourceRequest::toHttpDateString(uint64_t msecsSinceEpoch) {
-    return QLocale::c()
-        .toString(QDateTime::fromMSecsSinceEpoch(msecsSinceEpoch), QLatin1String("ddd, dd MMM yyyy hh:mm:ss 'GMT'"))
+    return QDateTime::fromMSecsSinceEpoch(msecsSinceEpoch)
+        .toString("ddd, dd MMM yyyy hh:mm:ss 'GMT'")
         .toLatin1();
 }
 

--- a/libraries/networking/src/ResourceRequest.h
+++ b/libraries/networking/src/ResourceRequest.h
@@ -90,6 +90,7 @@ public:
     void setCacheEnabled(bool value) { _cacheEnabled = value; }
     void setByteRange(ByteRange byteRange) { _byteRange = byteRange; }
 
+    static QString toHttpDateString(uint64_t msecsSinceEpoch);
 public slots:
     void send();
 

--- a/libraries/script-engine/src/ScriptCache.cpp
+++ b/libraries/script-engine/src/ScriptCache.cpp
@@ -87,8 +87,8 @@ void ScriptCache::getScriptContents(const QString& scriptOrURL, contentAvailable
     if (_scriptCache.contains(url) && !forceDownload) {
         auto entry = _scriptCache[url];
         if (url.isLocalFile() || url.scheme().isEmpty()) {
-            auto mtime = QFileInfo(url.toLocalFile()).lastModified();
-            QString localTime = ResourceRequest::toHttpDateString(mtime.toMSecsSinceEpoch());
+            auto modifiedTime = QFileInfo(url.toLocalFile()).lastModified();
+            QString localTime = ResourceRequest::toHttpDateString(modifiedTime.toMSecsSinceEpoch());
             QString cachedTime = entry["last-modified"].toString();
             if (cachedTime != localTime) {
                 forceDownload = true;
@@ -97,10 +97,10 @@ void ScriptCache::getScriptContents(const QString& scriptOrURL, contentAvailable
             }
         }
         if (!forceDownload) {
-          lock.unlock();
-          qCDebug(scriptengine) << "Found script in cache:" << url.fileName();
-          contentAvailable(url.toString(), entry["data"].toString(), true, true, STATUS_CACHED);
-          return;
+            lock.unlock();
+            qCDebug(scriptengine) << "Found script in cache:" << url.fileName();
+            contentAvailable(url.toString(), entry["data"].toString(), true, true, STATUS_CACHED);
+            return;
         }
     }
     {
@@ -155,8 +155,8 @@ void ScriptCache::scriptContentAvailable(int maxRetries) {
                 _activeScriptRequests.remove(url);
 
                 _scriptCache[url] = {
-                  { "data", scriptContent = req->getData() },
-                  { "last-modified", req->property("last-modified") },
+                    { "data", scriptContent = req->getData() },
+                    { "last-modified", req->property("last-modified") },
                 };
             } else {
                 auto result = req->getResult();

--- a/libraries/script-engine/src/ScriptCache.cpp
+++ b/libraries/script-engine/src/ScriptCache.cpp
@@ -85,11 +85,25 @@ void ScriptCache::getScriptContents(const QString& scriptOrURL, contentAvailable
 
     Lock lock(_containerLock);
     if (_scriptCache.contains(url) && !forceDownload) {
-        auto scriptContent = _scriptCache[url];
-        lock.unlock();
-        qCDebug(scriptengine) << "Found script in cache:" << url.fileName();
-        contentAvailable(url.toString(), scriptContent, true, true, STATUS_CACHED);
-    } else {
+        auto entry = _scriptCache[url];
+        if (url.isLocalFile() || url.scheme().isEmpty()) {
+            auto mtime = QFileInfo(url.toLocalFile()).lastModified();
+            QString localTime = ResourceRequest::toHttpDateString(mtime.toMSecsSinceEpoch());
+            QString cachedTime = entry["last-modified"].toString();
+            if (cachedTime != localTime) {
+                forceDownload = true;
+                qCDebug(scriptengine) << "Found script in cache, but local file modified; reloading:" << url.fileName()
+                                      << "(memory:" << cachedTime << "disk:" << localTime << ")";
+            }
+        }
+        if (!forceDownload) {
+          lock.unlock();
+          qCDebug(scriptengine) << "Found script in cache:" << url.fileName();
+          contentAvailable(url.toString(), entry["data"].toString(), true, true, STATUS_CACHED);
+          return;
+        }
+    }
+    {
         auto& scriptRequest = _activeScriptRequests[url];
         bool alreadyWaiting = scriptRequest.scriptUsers.size() > 0;
         scriptRequest.scriptUsers.push_back(contentAvailable);
@@ -140,7 +154,10 @@ void ScriptCache::scriptContentAvailable(int maxRetries) {
 
                 _activeScriptRequests.remove(url);
 
-                _scriptCache[url] = scriptContent = req->getData();
+                _scriptCache[url] = {
+                  { "data", scriptContent = req->getData() },
+                  { "last-modified", req->property("last-modified") },
+                };
             } else {
                 auto result = req->getResult();
                 bool irrecoverable =
@@ -177,7 +194,7 @@ void ScriptCache::scriptContentAvailable(int maxRetries) {
                     allCallbacks = scriptRequest.scriptUsers;
 
                     if (_scriptCache.contains(url)) {
-                        scriptContent = _scriptCache[url];
+                        scriptContent = _scriptCache[url]["data"].toString();
                     }
                     _activeScriptRequests.remove(url);
                     qCWarning(scriptengine) << "Error loading script from URL (" << status <<")";

--- a/libraries/script-engine/src/ScriptCache.h
+++ b/libraries/script-engine/src/ScriptCache.h
@@ -60,7 +60,7 @@ private:
     Mutex _containerLock;
     QMap<QUrl, ScriptRequest> _activeScriptRequests;
     
-    QHash<QUrl, QString> _scriptCache;
+    QHash<QUrl, QVariantMap> _scriptCache;
     QMultiMap<QUrl, ScriptUser*> _scriptUsers;
 };
 


### PR DESCRIPTION
This PR helps ScriptCache detect local file changes.

Before, when working on local Client Scripts that rely on `Script.require` to load modules in, it was impractical to reload inner local module dependencies (without resorting to hacks like `Script.require('./file.js?'+Date.now())`).

With this PR, simply reloading a Client Script will pick up any local file changes automatically.

Note that I also considered just never caching local paths ever -- however, in my case URLs that look like local files might actually be across network shares; so, by actually checking the modification time here, ScriptCache continues to work well in those scenarios too. 

### Test Plan

**Setup**: Create these two .js scripts in a local folder:
```js
// client-test.js
Script.require('./show-alert.js')
```
```js
// show-alert.js
Window.alert('“Um.” —First horse that got ridden');
```
1) Use Running Scripts... to load `client-test.js`
    - you should see the alert
2) Reload `client-test.js`
    - you should see the alert; and in the main app log:
    `[DEBUG] [hifi.scriptengine] Found script in cache: "show-alert.js"`
3) Make an external change to `show-alert.js` (eg: modify the message and resave).
4) Reload `client-test.js`
    - you should see the alert; and in the main app log:
    `[DEBUG] [hifi.scriptengine] Found script in cache, but local file modified; reloading: "show-alert.js" (memory: "Thu, 29 Oct 2020 10:47:30 GMT" disk: "Thu, 29 Oct 2020 11:22:40 GMT" )`
5) (without changing anything) Reload `client-test.js` again:
    - you should see the alert; and in the main app log:
    `[DEBUG] [hifi.scriptengine] Found script in cache: "show-alert.js"`

//