### PR TITLE
Create App. - Feature Bundle - Nov 2020

### DIFF
--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -160,6 +160,7 @@ var SETTING_AUTO_FOCUS_ON_SELECT = "autoFocusOnSelect";
 var SETTING_EASE_ON_FOCUS = "cameraEaseOnFocus";
 var SETTING_SHOW_LIGHTS_AND_PARTICLES_IN_EDIT_MODE = "showLightsAndParticlesInEditMode";
 var SETTING_SHOW_ZONES_IN_EDIT_MODE = "showZonesInEditMode";
+var SETTING_EDITOR_COLUMNS_SETUP = "editorColumnsSetup";
 
 var SETTING_EDIT_PREFIX = "Edit/";
 

--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -146,11 +146,11 @@ var DEFAULT_DIMENSIONS = {
 
 var DEFAULT_LIGHT_DIMENSIONS = Vec3.multiply(20, DEFAULT_DIMENSIONS);
 
+var SUBMENU_ENTITY_EDITOR_PREFERENCES = "Edit > Create Application - Preferences";
 var MENU_AUTO_FOCUS_ON_SELECT = "Auto Focus on Select";
 var MENU_EASE_ON_FOCUS = "Ease Orientation on Focus";
 var MENU_SHOW_LIGHTS_AND_PARTICLES_IN_EDIT_MODE = "Show Lights and Particle Systems in Create Mode";
 var MENU_SHOW_ZONES_IN_EDIT_MODE = "Show Zones in Create Mode";
-
 var MENU_CREATE_ENTITIES_GRABBABLE = "Create Entities As Grabbable (except Zones, Particles, and Lights)";
 var MENU_ALLOW_SELECTION_LARGE = "Allow Selecting of Large Models";
 var MENU_ALLOW_SELECTION_SMALL = "Allow Selecting of Small Models";
@@ -269,8 +269,6 @@ function adjustPositionPerBoundingBox(position, direction, registration, dimensi
     position = Vec3.sum(Vec3.multiply(distance, direction), position);
     return position;
 }
-
-var GRABBABLE_ENTITIES_MENU_CATEGORY = "Edit";
 
 // Handles any edit mode updates required when domains have switched
 function checkEditPermissionsAndUpdate() {
@@ -881,7 +879,12 @@ var toolBar = (function () {
 
         addButton("importEntitiesButton", function() {
             Window.browseChanged.connect(onFileOpenChanged);
-            Window.browseAsync("Select Model to Import", "", "*.json");
+            Window.browseAsync("Select .json to Import", "", "*.json");
+        });
+
+        addButton("importEntitiesFromUrlButton", function() {
+            Window.promptTextChanged.connect(onPromptTextChanged);
+            Window.promptAsync("URL of a .json to import", "");
         });
 
         addButton("openAssetBrowserButton", function() {
@@ -1381,11 +1384,9 @@ Controller.mouseReleaseEvent.connect(mouseReleaseEvent);
 // In order for editVoxels and editModels to play nice together, they each check to see if a "delete" menu item already
 // exists. If it doesn't they add it. If it does they don't. They also only delete the menu item if they were the one that
 // added it.
-var modelMenuAddedDelete = false;
 var originalLightsArePickable = Entities.getLightsArePickable();
 
 function setupModelMenus() {
-    // adj our menuitems
     Menu.addMenuItem({
         menuName: "Edit",
         menuItemName: "Undo",
@@ -1399,120 +1400,66 @@ function setupModelMenus() {
         position: 1,
     });
 
-    Menu.addMenuItem({
-        menuName: "Edit",
-        menuItemName: "Entities",
-        isSeparator: true
-    });
-    if (!Menu.menuItemExists("Edit", "Delete")) {
-        Menu.addMenuItem({
-            menuName: "Edit",
-            menuItemName: "Delete",
-            shortcutKeyEvent: {
-                text: "delete"
-            },
-            afterItem: "Entities",
-        });
-        modelMenuAddedDelete = true;
-    }
+    Menu.addMenu(SUBMENU_ENTITY_EDITOR_PREFERENCES);
 
     Menu.addMenuItem({
-        menuName: "Edit",
-        menuItemName: "Parent Entity to Last",
-        afterItem: "Entities"
-    });
-
-    Menu.addMenuItem({
-        menuName: "Edit",
-        menuItemName: "Unparent Entity",
-        afterItem: "Parent Entity to Last"
-    });
-
-    Menu.addMenuItem({
-        menuName: GRABBABLE_ENTITIES_MENU_CATEGORY,
+        menuName: SUBMENU_ENTITY_EDITOR_PREFERENCES,
         menuItemName: MENU_CREATE_ENTITIES_GRABBABLE,
-        afterItem: "Unparent Entity",
+        position: 0,
         isCheckable: true,
         isChecked: Settings.getValue(SETTING_EDIT_PREFIX + MENU_CREATE_ENTITIES_GRABBABLE, false)
     });
-
     Menu.addMenuItem({
-        menuName: "Edit",
+        menuName: SUBMENU_ENTITY_EDITOR_PREFERENCES,
         menuItemName: MENU_ALLOW_SELECTION_LARGE,
         afterItem: MENU_CREATE_ENTITIES_GRABBABLE,
         isCheckable: true,
         isChecked: Settings.getValue(SETTING_EDIT_PREFIX + MENU_ALLOW_SELECTION_LARGE, true)
     });
     Menu.addMenuItem({
-        menuName: "Edit",
+        menuName: SUBMENU_ENTITY_EDITOR_PREFERENCES,
         menuItemName: MENU_ALLOW_SELECTION_SMALL,
         afterItem: MENU_ALLOW_SELECTION_LARGE,
         isCheckable: true,
         isChecked: Settings.getValue(SETTING_EDIT_PREFIX + MENU_ALLOW_SELECTION_SMALL, true)
     });
     Menu.addMenuItem({
-        menuName: "Edit",
+        menuName: SUBMENU_ENTITY_EDITOR_PREFERENCES,
         menuItemName: MENU_ALLOW_SELECTION_LIGHTS,
         afterItem: MENU_ALLOW_SELECTION_SMALL,
         isCheckable: true,
         isChecked: Settings.getValue(SETTING_EDIT_PREFIX + MENU_ALLOW_SELECTION_LIGHTS, false)
     });
     Menu.addMenuItem({
-        menuName: "Edit",
-        menuItemName: "Select All Entities In Box",
-        afterItem: "Allow Selecting of Lights"
-    });
-    Menu.addMenuItem({
-        menuName: "Edit",
-        menuItemName: "Select All Entities Touching Box",
-        afterItem: "Select All Entities In Box"
-    });
-
-    Menu.addMenuItem({
-        menuName: "Edit",
-        menuItemName: "Export Entities",
-        afterItem: "Entities"
-    });
-    Menu.addMenuItem({
-        menuName: "Edit",
-        menuItemName: "Import Entities",
-        afterItem: "Export Entities"
-    });
-    Menu.addMenuItem({
-        menuName: "Edit",
-        menuItemName: "Import Entities from URL",
-        afterItem: "Import Entities"
-    });
-
-    Menu.addMenuItem({
-        menuName: "Edit",
+        menuName: SUBMENU_ENTITY_EDITOR_PREFERENCES,
         menuItemName: MENU_AUTO_FOCUS_ON_SELECT,
+        afterItem: MENU_ALLOW_SELECTION_LIGHTS,
         isCheckable: true,
         isChecked: Settings.getValue(SETTING_AUTO_FOCUS_ON_SELECT) === "true"
     });
     Menu.addMenuItem({
-        menuName: "Edit",
+        menuName: SUBMENU_ENTITY_EDITOR_PREFERENCES,
         menuItemName: MENU_EASE_ON_FOCUS,
         afterItem: MENU_AUTO_FOCUS_ON_SELECT,
         isCheckable: true,
         isChecked: Settings.getValue(SETTING_EASE_ON_FOCUS) === "true"
     });
     Menu.addMenuItem({
-        menuName: "Edit",
+        menuName: SUBMENU_ENTITY_EDITOR_PREFERENCES,
         menuItemName: MENU_SHOW_LIGHTS_AND_PARTICLES_IN_EDIT_MODE,
         afterItem: MENU_EASE_ON_FOCUS,
         isCheckable: true,
         isChecked: Settings.getValue(SETTING_SHOW_LIGHTS_AND_PARTICLES_IN_EDIT_MODE) !== "false"
     });
     Menu.addMenuItem({
-        menuName: "Edit",
+        menuName: SUBMENU_ENTITY_EDITOR_PREFERENCES,
         menuItemName: MENU_SHOW_ZONES_IN_EDIT_MODE,
         afterItem: MENU_SHOW_LIGHTS_AND_PARTICLES_IN_EDIT_MODE,
         isCheckable: true,
         isChecked: Settings.getValue(SETTING_SHOW_ZONES_IN_EDIT_MODE) !== "false"
     });
     Menu.addMenuItem({
-        menuName: "Edit",
+        menuName: SUBMENU_ENTITY_EDITOR_PREFERENCES,
         menuItemName: MENU_ENTITY_LIST_DEFAULT_RADIUS,
         afterItem: MENU_SHOW_ZONES_IN_EDIT_MODE
     });
@@ -1526,30 +1473,16 @@ function cleanupModelMenus() {
     Menu.removeMenuItem("Edit", "Undo");
     Menu.removeMenuItem("Edit", "Redo");
 
-    Menu.removeSeparator("Edit", "Entities");
-    if (modelMenuAddedDelete) {
-        // delete our menuitems
-        Menu.removeMenuItem("Edit", "Delete");
-    }
-
-    Menu.removeMenuItem("Edit", "Parent Entity to Last");
-    Menu.removeMenuItem("Edit", "Unparent Entity");
-    Menu.removeMenuItem("Edit", "Allow Selecting of Large Models");
-    Menu.removeMenuItem("Edit", "Allow Selecting of Small Models");
-    Menu.removeMenuItem("Edit", "Allow Selecting of Lights");
-    Menu.removeMenuItem("Edit", "Select All Entities In Box");
-    Menu.removeMenuItem("Edit", "Select All Entities Touching Box");
-
-    Menu.removeMenuItem("Edit", "Export Entities");
-    Menu.removeMenuItem("Edit", "Import Entities");
-    Menu.removeMenuItem("Edit", "Import Entities from URL");
-
-    Menu.removeMenuItem("Edit", MENU_AUTO_FOCUS_ON_SELECT);
-    Menu.removeMenuItem("Edit", MENU_EASE_ON_FOCUS);
-    Menu.removeMenuItem("Edit", MENU_SHOW_LIGHTS_AND_PARTICLES_IN_EDIT_MODE);
-    Menu.removeMenuItem("Edit", MENU_SHOW_ZONES_IN_EDIT_MODE);
-    Menu.removeMenuItem("Edit", MENU_CREATE_ENTITIES_GRABBABLE);
-    Menu.removeMenuItem("Edit", MENU_ENTITY_LIST_DEFAULT_RADIUS);
+    Menu.removeMenuItem(SUBMENU_ENTITY_EDITOR_PREFERENCES, MENU_ALLOW_SELECTION_LARGE);
+    Menu.removeMenuItem(SUBMENU_ENTITY_EDITOR_PREFERENCES, MENU_ALLOW_SELECTION_SMALL);
+    Menu.removeMenuItem(SUBMENU_ENTITY_EDITOR_PREFERENCES, MENU_ALLOW_SELECTION_LIGHTS);
+    Menu.removeMenuItem(SUBMENU_ENTITY_EDITOR_PREFERENCES, MENU_AUTO_FOCUS_ON_SELECT);
+    Menu.removeMenuItem(SUBMENU_ENTITY_EDITOR_PREFERENCES, MENU_EASE_ON_FOCUS);
+    Menu.removeMenuItem(SUBMENU_ENTITY_EDITOR_PREFERENCES, MENU_SHOW_LIGHTS_AND_PARTICLES_IN_EDIT_MODE);
+    Menu.removeMenuItem(SUBMENU_ENTITY_EDITOR_PREFERENCES, MENU_SHOW_ZONES_IN_EDIT_MODE);
+    Menu.removeMenuItem(SUBMENU_ENTITY_EDITOR_PREFERENCES, MENU_CREATE_ENTITIES_GRABBABLE);
+    Menu.removeMenuItem(SUBMENU_ENTITY_EDITOR_PREFERENCES, MENU_ENTITY_LIST_DEFAULT_RADIUS);
+    Menu.removeMenu(SUBMENU_ENTITY_EDITOR_PREFERENCES);   
 }
 
 Script.scriptEnding.connect(function () {
@@ -1902,41 +1835,18 @@ function onPromptTextChangedDefaultRadiusUserPref(prompt) {
 }
 
 function handleMenuEvent(menuItem) {
-    if (menuItem === "Allow Selecting of Small Models") {
-        allowSmallModels = Menu.isOptionChecked("Allow Selecting of Small Models");
-    } else if (menuItem === "Allow Selecting of Large Models") {
-        allowLargeModels = Menu.isOptionChecked("Allow Selecting of Large Models");
-    } else if (menuItem === "Allow Selecting of Lights") {
-        Entities.setLightsArePickable(Menu.isOptionChecked("Allow Selecting of Lights"));
+    if (menuItem === MENU_ALLOW_SELECTION_SMALL) {
+        allowSmallModels = Menu.isOptionChecked(MENU_ALLOW_SELECTION_SMALL);
+    } else if (menuItem === MENU_ALLOW_SELECTION_LARGE) {
+        allowLargeModels = Menu.isOptionChecked(MENU_ALLOW_SELECTION_LARGE);
+    } else if (menuItem === MENU_ALLOW_SELECTION_LIGHTS) {
+        Entities.setLightsArePickable(Menu.isOptionChecked(MENU_ALLOW_SELECTION_LIGHTS));
     } else if (menuItem === "Delete") {
         deleteSelectedEntities();
     } else if (menuItem === "Undo") {
         undoHistory.undo();
     } else if (menuItem === "Redo") {
         undoHistory.redo();
-    } else if (menuItem === "Parent Entity to Last") {
-        parentSelectedEntities();
-    } else if (menuItem === "Unparent Entity") {
-        unparentSelectedEntities();
-    } else if (menuItem === "Export Entities") {
-        if (!selectionManager.hasSelection()) {
-            Window.notifyEditError("No entities have been selected.");
-        } else {
-            Window.saveFileChanged.connect(onFileSaveChanged);
-            Window.saveAsync("Select Where to Save", "", "*.json");
-        }
-    } else if (menuItem === "Import Entities" || menuItem === "Import Entities from URL") {
-        if (menuItem === "Import Entities") {
-            Window.browseChanged.connect(onFileOpenChanged);
-            Window.browseAsync("Select Model to Import", "", "*.json");
-        } else {
-            Window.promptTextChanged.connect(onPromptTextChanged);
-            Window.promptAsync("URL of a .json to import", "");         
-        }
-    } else if (menuItem === "Select All Entities In Box") {
-        selectAllEntitiesInCurrentSelectionBox(false);
-    } else if (menuItem === "Select All Entities Touching Box") {
-        selectAllEntitiesInCurrentSelectionBox(true);
     } else if (menuItem === MENU_SHOW_LIGHTS_AND_PARTICLES_IN_EDIT_MODE) {
         entityIconOverlayManager.setVisible(isActive && Menu.isOptionChecked(MENU_SHOW_LIGHTS_AND_PARTICLES_IN_EDIT_MODE));
     } else if (menuItem === MENU_SHOW_ZONES_IN_EDIT_MODE) {

--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -155,12 +155,14 @@ var MENU_CREATE_ENTITIES_GRABBABLE = "Create Entities As Grabbable (except Zones
 var MENU_ALLOW_SELECTION_LARGE = "Allow Selecting of Large Models";
 var MENU_ALLOW_SELECTION_SMALL = "Allow Selecting of Small Models";
 var MENU_ALLOW_SELECTION_LIGHTS = "Allow Selecting of Lights";
+var MENU_ENTITY_LIST_DEFAULT_RADIUS = "Entity List Default Radius";
 
 var SETTING_AUTO_FOCUS_ON_SELECT = "autoFocusOnSelect";
 var SETTING_EASE_ON_FOCUS = "cameraEaseOnFocus";
 var SETTING_SHOW_LIGHTS_AND_PARTICLES_IN_EDIT_MODE = "showLightsAndParticlesInEditMode";
 var SETTING_SHOW_ZONES_IN_EDIT_MODE = "showZonesInEditMode";
 var SETTING_EDITOR_COLUMNS_SETUP = "editorColumnsSetup";
+var SETTING_ENTITY_LIST_DEFAULT_RADIUS = "entityListDefaultRadius";
 
 var SETTING_EDIT_PREFIX = "Edit/";
 
@@ -1509,6 +1511,11 @@ function setupModelMenus() {
         isCheckable: true,
         isChecked: Settings.getValue(SETTING_SHOW_ZONES_IN_EDIT_MODE) !== "false"
     });
+    Menu.addMenuItem({
+        menuName: "Edit",
+        menuItemName: MENU_ENTITY_LIST_DEFAULT_RADIUS,
+        afterItem: MENU_SHOW_ZONES_IN_EDIT_MODE
+    });
 
     Entities.setLightsArePickable(false);
 }
@@ -1542,6 +1549,7 @@ function cleanupModelMenus() {
     Menu.removeMenuItem("Edit", MENU_SHOW_LIGHTS_AND_PARTICLES_IN_EDIT_MODE);
     Menu.removeMenuItem("Edit", MENU_SHOW_ZONES_IN_EDIT_MODE);
     Menu.removeMenuItem("Edit", MENU_CREATE_ENTITIES_GRABBABLE);
+    Menu.removeMenuItem("Edit", MENU_ENTITY_LIST_DEFAULT_RADIUS);
 }
 
 Script.scriptEnding.connect(function () {
@@ -1882,6 +1890,17 @@ function onPromptTextChanged(prompt) {
     }
 }
 
+function onPromptTextChangedDefaultRadiusUserPref(prompt) {
+    Window.promptTextChanged.disconnect(onPromptTextChangedDefaultRadiusUserPref);
+    if (prompt !== "") {
+        var radius = parseInt(prompt);
+        if (radius < 0 || isNaN(radius)){
+            radius = 100;
+        }
+        Settings.setValue(SETTING_ENTITY_LIST_DEFAULT_RADIUS, radius);
+    }
+}
+
 function handleMenuEvent(menuItem) {
     if (menuItem === "Allow Selecting of Small Models") {
         allowSmallModels = Menu.isOptionChecked("Allow Selecting of Small Models");
@@ -1912,7 +1931,7 @@ function handleMenuEvent(menuItem) {
             Window.browseAsync("Select Model to Import", "", "*.json");
         } else {
             Window.promptTextChanged.connect(onPromptTextChanged);
-            Window.promptAsync("URL of SVO to import", "");
+            Window.promptAsync("URL of a .json to import", "");         
         }
     } else if (menuItem === "Select All Entities In Box") {
         selectAllEntitiesInCurrentSelectionBox(false);
@@ -1924,6 +1943,9 @@ function handleMenuEvent(menuItem) {
         Entities.setDrawZoneBoundaries(isActive && Menu.isOptionChecked(MENU_SHOW_ZONES_IN_EDIT_MODE));
     } else if (menuItem === MENU_CREATE_ENTITIES_GRABBABLE) {
         Settings.setValue(SETTING_EDIT_PREFIX + menuItem, Menu.isOptionChecked(menuItem));
+    } else if (menuItem === MENU_ENTITY_LIST_DEFAULT_RADIUS) {
+        Window.promptTextChanged.connect(onPromptTextChangedDefaultRadiusUserPref);
+        Window.promptAsync("Entity List Default Radius (in meters)", "" + Settings.getValue(SETTING_ENTITY_LIST_DEFAULT_RADIUS, 100));         
     }
     tooltip.show(false);
 }

--- a/scripts/system/create/entityList/entityList.js
+++ b/scripts/system/create/entityList/entityList.js
@@ -371,6 +371,14 @@ EntityListTool = function(shouldUseEditTabletApp) {
             SelectionManager.teleportToEntity();
         } else if (data.type === 'moveEntitySelectionToAvatar') {
             SelectionManager.moveEntitiesSelectionToAvatar();
+        } else if (data.type === 'loadColumnsConfigSetting') {
+            var columnsData = Settings.getValue(SETTING_EDIT_PREFIX + SETTING_EDITOR_COLUMNS_SETUP, "NO_DATA");
+            emitJSONScriptEvent({
+                "type": "loadedColumnsSetup",
+                "columnsData": columnsData
+            });
+        } else if (data.type === 'saveColumnsConfigSetting') {
+            Settings.setValue(SETTING_EDIT_PREFIX + SETTING_EDITOR_COLUMNS_SETUP, data.columnsData);
         }
     };
 

--- a/scripts/system/create/entityList/entityList.js
+++ b/scripts/system/create/entityList/entityList.js
@@ -371,14 +371,16 @@ EntityListTool = function(shouldUseEditTabletApp) {
             SelectionManager.teleportToEntity();
         } else if (data.type === 'moveEntitySelectionToAvatar') {
             SelectionManager.moveEntitiesSelectionToAvatar();
-        } else if (data.type === 'loadColumnsConfigSetting') {
-            var columnsData = Settings.getValue(SETTING_EDIT_PREFIX + SETTING_EDITOR_COLUMNS_SETUP, "NO_DATA");
+        } else if (data.type === 'loadConfigSetting') {
+            var columnsData = Settings.getValue(SETTING_EDITOR_COLUMNS_SETUP, "NO_DATA");
+            var defaultRadius = Settings.getValue(SETTING_ENTITY_LIST_DEFAULT_RADIUS, 100);
             emitJSONScriptEvent({
-                "type": "loadedColumnsSetup",
-                "columnsData": columnsData
+                "type": "loadedConfigSetting",
+                "columnsData": columnsData,
+                "defaultRadius": defaultRadius
             });
         } else if (data.type === 'saveColumnsConfigSetting') {
-            Settings.setValue(SETTING_EDIT_PREFIX + SETTING_EDITOR_COLUMNS_SETUP, data.columnsData);
+            Settings.setValue(SETTING_EDITOR_COLUMNS_SETUP, data.columnsData);
         }
     };
 

--- a/scripts/system/create/entityList/html/entityList.html
+++ b/scripts/system/create/entityList/html/entityList.html
@@ -215,13 +215,13 @@
             </button>
             <button class="menu-button" id="selectfamily" >
                 <div class = "menu-item">
-                    <div class = "menu-item-caption">Select Family</div>
+                    <div class = "menu-item-caption">Select Parent And All Its Children</div>
                     <div class = "menu-item-shortcut"></div>
                 </div>
             </button>
             <button class="menu-button" id="selecttopfamily" >
                 <div class = "menu-item">
-                    <div class = "menu-item-caption">Select Top Family</div>
+                    <div class = "menu-item-caption">Select Top Parent And All Its Children</div>
                     <div class = "menu-item-shortcut"></div>
                 </div>
             </button>

--- a/scripts/system/create/entityList/html/entityList.html
+++ b/scripts/system/create/entityList/html/entityList.html
@@ -154,7 +154,13 @@
                     <div class = "menu-item-caption">Move Selected Entities to Avatar</div>
                     <div class = "menu-item-shortcut"></div>
                 </div>
-            </button>            
+            </button>
+            <button class="menu-button" id="teleport-to-entity" >
+                <div class = "menu-item">
+                    <div class = "menu-item-caption">Teleport To Selected Entities</div>
+                    <div class = "menu-item-shortcut"></div>
+                </div>
+            </button>
         </div>
         <div class="entity-list-menu" id="selection-menu" >
             <button class="menu-button" id="selectall" >
@@ -218,14 +224,7 @@
                     <div class = "menu-item-caption">Select Top Family</div>
                     <div class = "menu-item-shortcut"></div>
                 </div>
-            </button>            
-            <div class="menu-separator"></div>
-            <button class="menu-button" id="teleport-to-entity" >
-                <div class = "menu-item">
-                    <div class = "menu-item-caption">Teleport To Selected Entities</div>
-                    <div class = "menu-item-shortcut"></div>
-                </div>
-            </button>      
+            </button>
         </div>
         <div id="menuBackgroundOverlay" ></div>
     </body>

--- a/scripts/system/create/entityList/html/entityList.html
+++ b/scripts/system/create/entityList/html/entityList.html
@@ -155,12 +155,6 @@
                     <div class = "menu-item-shortcut"></div>
                 </div>
             </button>
-            <button class="menu-button" id="teleport-to-entity" >
-                <div class = "menu-item">
-                    <div class = "menu-item-caption">Teleport To Selected Entities</div>
-                    <div class = "menu-item-shortcut"></div>
-                </div>
-            </button>
         </div>
         <div class="entity-list-menu" id="selection-menu" >
             <button class="menu-button" id="selectall" >
@@ -225,6 +219,13 @@
                     <div class = "menu-item-shortcut"></div>
                 </div>
             </button>
+            <div class="menu-separator"></div>
+            <button class="menu-button" id="teleport-to-entity" >
+                <div class = "menu-item">
+                    <div class = "menu-item-caption">Teleport To Selected Entities</div>
+                    <div class = "menu-item-shortcut"></div>
+                </div>
+            </button>            
         </div>
         <div id="menuBackgroundOverlay" ></div>
     </body>

--- a/scripts/system/create/entityList/html/entityList.html
+++ b/scripts/system/create/entityList/html/entityList.html
@@ -225,7 +225,7 @@
                     <div class = "menu-item-caption">Teleport To Selected Entities</div>
                     <div class = "menu-item-shortcut"></div>
                 </div>
-            </button>            
+            </button>
         </div>
         <div id="menuBackgroundOverlay" ></div>
     </body>

--- a/scripts/system/create/entityList/html/js/entityList.js
+++ b/scripts/system/create/entityList/html/js/entityList.js
@@ -1679,7 +1679,11 @@ function loaded() {
                     } else {
                         document.getElementById("hmdmultiselect").style.display = "none";                      
                     }
-                } else if (data.type === "loadedColumnsSetup") {
+                } else if (data.type === "loadedConfigSetting") {
+                    if (typeof(data.defaultRadius) === "number") {
+                        elFilterRadius.value = data.defaultRadius;
+                        onRadiusChange();
+                    }
                     if (data.columnsData !== "NO_DATA" && typeof(data.columnsData) === "object") {
                         var isValid = true;
                         var originalColumnIDs = [];
@@ -1731,7 +1735,7 @@ function loaded() {
         
         window.addEventListener("resize", updateColumnWidths);
         
-        EventBridge.emitWebEvent(JSON.stringify({ type: 'loadColumnsConfigSetting' }));
+        EventBridge.emitWebEvent(JSON.stringify({ type: 'loadConfigSetting' }));
     });
     
     augmentSpinButtons();

--- a/scripts/system/create/entityList/html/js/entityList.js
+++ b/scripts/system/create/entityList/html/js/entityList.js
@@ -1735,6 +1735,7 @@ function loaded() {
     // close context menu when switching focus to another window
     $(window).blur(function() {
         entityListContextMenu.close();
+        closeAllEntityListMenu();
     });
     
     function closeAllEntityListMenu() {

--- a/scripts/system/create/entityList/html/js/entityList.js
+++ b/scripts/system/create/entityList/html/js/entityList.js
@@ -188,6 +188,8 @@ let selectedEntities = [];
 let entityList = null; // The ListView
 
 let hmdMultiSelectMode = false; 
+
+let lastSelectedEntity;
 /**
  * @type EntityListContextMenu
  */
@@ -1047,6 +1049,8 @@ function loaded() {
         function updateSelectedEntities(selectedIDs, autoScroll) {
             let notFound = false;
 
+            lastSelectedEntity = selectedIDs[selectedIDs.length - 1];
+
             // reset all currently selected entities and their rows first
             selectedEntities.forEach(function(id) {
                 let entity = entitiesByID[id];
@@ -1066,7 +1070,11 @@ function loaded() {
                 if (entity !== undefined) {
                     entity.selected = true;
                     if (entity.elRow) {
-                        entity.elRow.className = 'selected';
+                        if (id === lastSelectedEntity) {
+                            entity.elRow.className = 'last-selected';
+                        } else {
+                            entity.elRow.className = 'selected';
+                        }
                     }
                 } else {
                     notFound = true;
@@ -1135,7 +1143,11 @@ function loaded() {
 
             // if this entity was previously selected flag it's row as selected
             if (itemData.selected) {
-                elRow.className = 'selected';
+                if (itemData.id === lastSelectedEntity) {
+                    elRow.className = 'last-selected';
+                } else {
+                    elRow.className = 'selected';
+                }
             } else {
                 elRow.className = '';
             }

--- a/scripts/system/create/entityList/html/js/entityList.js
+++ b/scripts/system/create/entityList/html/js/entityList.js
@@ -1714,9 +1714,9 @@ function loaded() {
                                 let currentColumnIndex = originalColumnIDs.indexOf(data.columnsData[columnIndex].columnID);
                                 if (currentColumnIndex !== -1 && columnIndex !== currentColumnIndex) {
                                     for (var i = currentColumnIndex; i > columnIndex; i--) {
-                                        swapColumns(i-1, i);
-                                        var swappedContent = originalColumnIDs[i-1];  
-                                        originalColumnIDs[i-1] = originalColumnIDs[i];  
+                                        swapColumns(i - 1, i);
+                                        var swappedContent = originalColumnIDs[i - 1];  
+                                        originalColumnIDs[i - 1] = originalColumnIDs[i];  
                                         originalColumnIDs[i] = swappedContent;                                        
                                     }
                                 }

--- a/scripts/system/create/entityList/html/js/entityList.js
+++ b/scripts/system/create/entityList/html/js/entityList.js
@@ -770,10 +770,10 @@ function loaded() {
                 let selectedIndex = selectedEntities.indexOf(entityID);
                 if (selectedIndex >= 0) {
                     selection = [];
-                    selection = selection.concat(selectedEntities);
+                    selection = selectedEntities.concat(selection);
                     selection.splice(selectedIndex, 1);
                 } else {
-                    selection = selection.concat(selectedEntities);
+                    selection = selectedEntities.concat(selection);
                 }
             } else if (clickEvent.shiftKey && selectedEntities.length > 0) {
                 let previousItemFound = -1;

--- a/scripts/system/create/entitySelectionTool/entitySelectionTool.js
+++ b/scripts/system/create/entitySelectionTool/entitySelectionTool.js
@@ -798,6 +798,7 @@ SelectionDisplay = (function() {
     const COLOR_ROTATE_CURRENT_RING = { red: 255, green: 99, blue: 9 };
     const COLOR_BOUNDING_EDGE = { red: 160, green: 160, blue: 160 };
     const COLOR_BOUNDING_EDGE_PARENT = { red: 194, green: 123, blue: 0 };
+    const COLOR_BOUNDING_EDGE_PARENT_AND_CHILDREN = { red: 179, green: 0, blue: 134 };
     const COLOR_BOUNDING_EDGE_CHILDREN = { red: 0, green: 168, blue: 214 };
     const COLOR_SCALE_CUBE = { red: 192, green: 192, blue: 192 };
     const COLOR_DEBUG_PICK_PLANE = { red: 255, green: 255, blue: 255 };
@@ -1934,10 +1935,10 @@ SelectionDisplay = (function() {
                 var parentState = getParentState(SelectionManager.selections[0]);
                 if (parentState === "CHILDREN") {
                     handleBoundingBoxColor = COLOR_BOUNDING_EDGE_CHILDREN;
-                } else {
-                    if (parentState === "PARENT" || parentState === "PARENT_CHILDREN") {
-                        handleBoundingBoxColor = COLOR_BOUNDING_EDGE_PARENT;
-                    }
+                } else if (parentState === "PARENT") {
+                    handleBoundingBoxColor = COLOR_BOUNDING_EDGE_PARENT;
+                } else if (parentState === "PARENT_CHILDREN") {
+                    handleBoundingBoxColor = COLOR_BOUNDING_EDGE_PARENT_AND_CHILDREN;
                 }
             }
             

--- a/scripts/system/create/entitySelectionTool/entitySelectionTool.js
+++ b/scripts/system/create/entitySelectionTool/entitySelectionTool.js
@@ -668,6 +668,7 @@ SelectionManager = (function() {
                 var newPosition = Vec3.sum(relativePosition, targetPosition);
                 Entities.editEntity(id, { "position": newPosition });
             }
+            pushCommandForSelections();
             that._update(false, this);
         } else {
             audioFeedback.rejection();

--- a/scripts/system/create/qml/EditTabView.qml
+++ b/scripts/system/create/qml/EditTabView.qml
@@ -201,11 +201,11 @@ TabBar {
 
                     HifiControls.Button {
                         id: importButton
-                        text: "Import Entities (.json)"
+                        text: "Import Entities (.json) from a File"
                         color: hifi.buttons.black
                         colorScheme: hifi.colorSchemes.dark
-                        anchors.right: parent.right
-                        anchors.rightMargin: 30
+                        anchors.right: parent.horizontalCenter
+                        anchors.rightMargin: 10
                         anchors.left: parent.left
                         anchors.leftMargin: 30
                         anchors.top: assetServerButton.bottom
@@ -214,6 +214,25 @@ TabBar {
                             editRoot.sendToScript({
                                 method: "newEntityButtonClicked",
                                 params: { buttonName: "importEntitiesButton" }
+                            });
+                        }
+                    }
+                    
+                    HifiControls.Button {
+                        id: importButtonFromUrl
+                        text: "Import Entities (.json) from a URL"
+                        color: hifi.buttons.black
+                        colorScheme: hifi.colorSchemes.dark
+                        anchors.right: parent.right
+                        anchors.rightMargin: 30
+                        anchors.left: parent.horizontalCenter
+                        anchors.leftMargin: 10
+                        anchors.top: assetServerButton.bottom
+                        anchors.topMargin: 20
+                        onClicked: {
+                            editRoot.sendToScript({
+                                method: "newEntityButtonClicked",
+                                params: { buttonName: "importEntitiesFromUrlButton" }
                             });
                         }
                     }

--- a/scripts/system/create/qml/EditToolsTabView.qml
+++ b/scripts/system/create/qml/EditToolsTabView.qml
@@ -211,7 +211,7 @@ TabBar {
                         color: hifi.buttons.black
                         colorScheme: hifi.colorSchemes.dark
                         anchors.right: parent.horizontalCenter
-                        anchors.rightMargin: 10                        
+                        anchors.rightMargin: 10
                         anchors.left: parent.left
                         anchors.leftMargin: 55
                         anchors.top: assetServerButton.bottom
@@ -241,7 +241,7 @@ TabBar {
                                 params: { buttonName: "importEntitiesFromUrlButton" }
                             });
                         }
-                    }                   
+                    }
                 }
             } // Flickable
         }

--- a/scripts/system/create/qml/EditToolsTabView.qml
+++ b/scripts/system/create/qml/EditToolsTabView.qml
@@ -207,11 +207,11 @@ TabBar {
 
                     HifiControls.Button {
                         id: importButton
-                        text: "Import Entities (.json)"
+                        text: "Import Entities (.json) from a File"
                         color: hifi.buttons.black
                         colorScheme: hifi.colorSchemes.dark
-                        anchors.right: parent.right
-                        anchors.rightMargin: 55
+                        anchors.right: parent.horizontalCenter
+                        anchors.rightMargin: 10                        
                         anchors.left: parent.left
                         anchors.leftMargin: 55
                         anchors.top: assetServerButton.bottom
@@ -223,6 +223,25 @@ TabBar {
                             });
                         }
                     }
+
+                    HifiControls.Button {
+                        id: importButtonFromUrl
+                        text: "Import Entities (.json) from a URL"
+                        color: hifi.buttons.black
+                        colorScheme: hifi.colorSchemes.dark
+                        anchors.right: parent.right
+                        anchors.rightMargin: 55
+                        anchors.left: parent.horizontalCenter
+                        anchors.leftMargin: 10
+                        anchors.top: assetServerButton.bottom
+                        anchors.topMargin: 20
+                        onClicked: {
+                            editRoot.sendToScript({
+                                method: "newEntityButtonClicked",
+                                params: { buttonName: "importEntitiesFromUrlButton" }
+                            });
+                        }
+                    }                   
                 }
             } // Flickable
         }

--- a/scripts/system/html/css/edit-style.css
+++ b/scripts/system/html/css/edit-style.css
@@ -109,7 +109,6 @@ table {
 thead {
     font-family: Raleway-Regular;
     font-size: 12px;
-    text-transform: uppercase;
     background-color: #1c1c1c;
     padding: 1px 0;
     border-bottom: 1px solid #575757;

--- a/scripts/system/html/css/edit-style.css
+++ b/scripts/system/html/css/edit-style.css
@@ -183,6 +183,15 @@ tr.selected + tr.selected {
     border-top: 1px solid #2e2e2e;
 }
 
+tr.last-selected {
+    color: #000000;
+    background-color: #0064ef;
+}
+
+tr.last-selected + tr.last-selected {
+    border-top: 1px solid #2e2e2e;
+}
+
 th {
     text-align: center;
     word-wrap: nowrap;


### PR DESCRIPTION
Contains:

1- **Entity List - Highlighting of the Last Selected entity**
The last selected entity is now displayed in darker blue in the list (if present per radius search)
This makes clearer which entity could become the parent.

2- Columns **visibility** and **order** are now **persistent**.

3- For clarity, "**Select Family**" and "**Select Top Family**" have been **renamed** respectively:
"**Select Parent And All Its Children**" and "**Select Top Parent And All Its Children**"

4- **New in-world bounding box color for a selected entity that is Parent & Child at the same time.**
When 1 entity is selected (in-world):
if the entity is a **Top Parent**, the selection color of the bounding box is **Orange**.
if the entity is **Parent and Child**, the selection color of the bounding box is **Majenta**. <=NEW!
if the entity is only a **Child**, then the selection color of the bounding box is **Cyan**.
If not involved in any parent line, or if the selection is multiple, then the selection color of the bounding box is **Light Grey**.

5- **Bug fix**: The "Selection" and "Actions" menu now close when we close the Entity list window or the Create App.

6- **Bug fix**: “Move Selected Entities to Avatar” is now recorded in the undo history. So undo/redo can be done.

7- **Bug fix**: EntityList, CTRL-Click was adding the last selected entity as the first selection the selection stack. The first selected item was systematically the last item of the selection. This was causing unpredictable results with "Parent Entities To The Last Selected". (This bug becomes evident by highlighting the "Last Selected" in the entity list.
