### PR TITLE
Fix GHA master build target branch

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -3,8 +3,7 @@ name: Master CI Build
 on: 
   push:
     branches:
-      - gha-master-ci
-# FIXME: Change target branch to "master" before merging into "master" branch.
+      - master
 
 env:
   APP_NAME: interface


### PR DESCRIPTION
Has no effect on PR builds.
Once merged, merges to master should start building. And should start building successfully once the following PR is merged: https://github.com/kasenvr/project-athena/pull/615